### PR TITLE
Add company-based color coding for TUI labels

### DIFF
--- a/cmd/odoo-work-cli/main.go
+++ b/cmd/odoo-work-cli/main.go
@@ -582,7 +582,7 @@ var tuiCmd = &cobra.Command{
 			return err
 		}
 
-		m := tui.NewModel(client, tui.MondayTime{Time: monday}, cfg.Hours, cfg.Bundesland, cfg.Keys)
+		m := tui.NewModel(client, tui.MondayTime{Time: monday}, cfg.Hours, cfg.Bundesland, cfg.Keys, cfg.CompanyColors)
 		p := tea.NewProgram(m)
 		_, err = p.Run()
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,14 +92,15 @@ func DefaultHoursLimits() HoursLimits {
 
 // Config holds the application configuration.
 type Config struct {
-	URL        string                 `toml:"url"`
-	Database   string                 `toml:"database"`
-	Username   string                 `toml:"username"`
-	Password   string                 `toml:"-"`
-	Models     map[string]ModelConfig `toml:"models"`
-	Hours      HoursLimits            `toml:"hours"`
-	Keys       KeysConfig             `toml:"keys"`
-	Bundesland string                 `toml:"bundesland"` // German federal state for holidays (e.g. "Bayern")
+	URL           string                 `toml:"url"`
+	Database      string                 `toml:"database"`
+	Username      string                 `toml:"username"`
+	Password      string                 `toml:"-"`
+	Models        map[string]ModelConfig `toml:"models"`
+	Hours         HoursLimits            `toml:"hours"`
+	Keys          KeysConfig             `toml:"keys"`
+	Bundesland    string                 `toml:"bundesland"`     // German federal state for holidays (e.g. "Bayern")
+	CompanyColors map[string]string      `toml:"company_colors"` // company name → lipgloss color string
 }
 
 func (c *Config) OdooURL() string      { return c.URL }
@@ -216,6 +217,14 @@ func (c *Config) Merge(other *Config) {
 		}
 		for action, keys := range other.Keys {
 			c.Keys[action] = keys
+		}
+	}
+	if other.CompanyColors != nil {
+		if c.CompanyColors == nil {
+			c.CompanyColors = make(map[string]string)
+		}
+		for name, color := range other.CompanyColors {
+			c.CompanyColors[name] = color
 		}
 	}
 	if other.Models != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -708,6 +708,105 @@ func TestMerge_Keys_NilBase(t *testing.T) {
 	}
 }
 
+func TestLoadFromTOML_CompanyColors(t *testing.T) {
+	content := `
+url = "https://odoo.example.com"
+
+[company_colors]
+"digitalgedacht GmbH" = "5"
+"nexiles GmbH" = "2"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromTOML(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CompanyColors == nil {
+		t.Fatal("CompanyColors is nil")
+	}
+	if got := cfg.CompanyColors["digitalgedacht GmbH"]; got != "5" {
+		t.Errorf("CompanyColors[digitalgedacht GmbH] = %q, want %q", got, "5")
+	}
+	if got := cfg.CompanyColors["nexiles GmbH"]; got != "2" {
+		t.Errorf("CompanyColors[nexiles GmbH] = %q, want %q", got, "2")
+	}
+}
+
+func TestLoadFromTOML_NoCompanyColors(t *testing.T) {
+	content := `url = "https://odoo.example.com"`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromTOML(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CompanyColors != nil {
+		t.Errorf("CompanyColors = %v, want nil when section absent", cfg.CompanyColors)
+	}
+}
+
+func TestMerge_CompanyColors(t *testing.T) {
+	base := &Config{
+		CompanyColors: map[string]string{
+			"Company A": "1",
+			"Company B": "2",
+		},
+	}
+	overlay := &Config{
+		CompanyColors: map[string]string{
+			"Company B": "5",
+			"Company C": "3",
+		},
+	}
+
+	base.Merge(overlay)
+
+	if got := base.CompanyColors["Company A"]; got != "1" {
+		t.Errorf("CompanyColors[Company A] = %q, want %q (base preserved)", got, "1")
+	}
+	if got := base.CompanyColors["Company B"]; got != "5" {
+		t.Errorf("CompanyColors[Company B] = %q, want %q (overlay replaces)", got, "5")
+	}
+	if got := base.CompanyColors["Company C"]; got != "3" {
+		t.Errorf("CompanyColors[Company C] = %q, want %q (overlay adds)", got, "3")
+	}
+}
+
+func TestMerge_CompanyColors_NilOverlay(t *testing.T) {
+	base := &Config{
+		CompanyColors: map[string]string{"Company A": "1"},
+	}
+	overlay := &Config{}
+
+	base.Merge(overlay)
+
+	if got := base.CompanyColors["Company A"]; got != "1" {
+		t.Errorf("CompanyColors[Company A] = %q, want %q (nil overlay preserves base)", got, "1")
+	}
+}
+
+func TestMerge_CompanyColors_NilBase(t *testing.T) {
+	base := &Config{}
+	overlay := &Config{
+		CompanyColors: map[string]string{"Company A": "1"},
+	}
+
+	base.Merge(overlay)
+
+	if got := base.CompanyColors["Company A"]; got != "1" {
+		t.Errorf("CompanyColors[Company A] = %q, want %q", got, "1")
+	}
+}
+
 func TestMerge_FiltersSameFieldOverride(t *testing.T) {
 	base := &Config{
 		Models: map[string]ModelConfig{

--- a/internal/odoo/client.go
+++ b/internal/odoo/client.go
@@ -45,6 +45,7 @@ type TimesheetEntry struct {
 	Hours           float64
 	Employee        string
 	ValidatedStatus string
+	Company         string
 }
 
 // TimesheetWriteParams holds parameters for creating or updating a timesheet entry.

--- a/internal/odoo/xmlrpc.go
+++ b/internal/odoo/xmlrpc.go
@@ -280,7 +280,7 @@ func (x *XMLRPCClient) ListTimesheets(dateFrom, dateTo string) ([]TimesheetEntry
 		Add("user_id.login", "=", x.login)
 	x.applyCriteriaFilters(criteria, "timesheet")
 
-	fields := []string{"id", "date", "project_id", "task_id", "name", "unit_amount", "employee_id", "validated_status"}
+	fields := []string{"id", "date", "project_id", "task_id", "name", "unit_amount", "employee_id", "validated_status", "company_id"}
 	opts := goOdoo.NewOptions().FetchFields(fields...)
 
 	records, err := x.searchReadRaw("account.analytic.line", criteria, opts)
@@ -299,6 +299,7 @@ func (x *XMLRPCClient) ListTimesheets(dateFrom, dateTo string) ([]TimesheetEntry
 			TaskID:    extractMany2OneID(r["task_id"]),
 			Task:      extractMany2OneName(r["task_id"]),
 			Employee:  extractMany2OneName(r["employee_id"]),
+			Company:   extractMany2OneName(r["company_id"]),
 		}
 		if id, ok := r["id"].(int64); ok {
 			entry.ID = id

--- a/internal/tui/grid.go
+++ b/internal/tui/grid.go
@@ -12,6 +12,7 @@ import (
 // GridRow represents a single project/task row in the weekly grid.
 type GridRow struct {
 	Label         string
+	Company       string                   // company name from first entry
 	Hours         [7]float64               // Mon=0 .. Sun=6
 	Entries       [7][]odoo.TimesheetEntry // individual entries per day
 	HintProjectID int64                    // from previous week, used when row has no entries
@@ -62,7 +63,7 @@ func BuildWeekGrid(entries []odoo.TimesheetEntry, monday time.Time) WeekGrid {
 		if !ok {
 			idx = len(g.Rows)
 			rowIndex[label] = idx
-			g.Rows = append(g.Rows, GridRow{Label: label})
+			g.Rows = append(g.Rows, GridRow{Label: label, Company: e.Company})
 		}
 		g.Rows[idx].Hours[dayOffset] += e.Hours
 		g.Rows[idx].Entries[dayOffset] = append(g.Rows[idx].Entries[dayOffset], e)
@@ -85,6 +86,7 @@ func BuildWeekGrid(entries []odoo.TimesheetEntry, monday time.Time) WeekGrid {
 // HintRow carries label and IDs from a previous week's entries to seed empty rows.
 type HintRow struct {
 	Label     string
+	Company   string
 	ProjectID int64
 	TaskID    int64
 }
@@ -104,6 +106,7 @@ func HintLabelsFromEntries(entries []odoo.TimesheetEntry) []HintRow {
 		seen[label] = true
 		hints = append(hints, HintRow{
 			Label:     label,
+			Company:   e.Company,
 			ProjectID: e.ProjectID,
 			TaskID:    e.TaskID,
 		})
@@ -136,7 +139,7 @@ func BuildWeekGridWithHints(entries []odoo.TimesheetEntry, monday time.Time, hin
 		if !ok {
 			idx = len(g.Rows)
 			rowIndex[label] = idx
-			g.Rows = append(g.Rows, GridRow{Label: label})
+			g.Rows = append(g.Rows, GridRow{Label: label, Company: e.Company})
 		}
 		g.Rows[idx].Hours[dayOffset] += e.Hours
 		g.Rows[idx].Entries[dayOffset] = append(g.Rows[idx].Entries[dayOffset], e)
@@ -151,6 +154,7 @@ func BuildWeekGridWithHints(entries []odoo.TimesheetEntry, monday time.Time, hin
 		rowIndex[h.Label] = idx
 		g.Rows = append(g.Rows, GridRow{
 			Label:         h.Label,
+			Company:       h.Company,
 			HintProjectID: h.ProjectID,
 			HintTaskID:    h.TaskID,
 		})

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -104,6 +104,8 @@ type Model struct {
 	editErr      error           // last edit error
 	editIsNew    bool            // true = creating new entry, false = editing existing
 
+	companyColors map[string]string // company name → lipgloss color
+
 	searchSub       searchSubState
 	searchInput     textinput.Model
 	searchItems     []searchItem // full combined list
@@ -119,7 +121,7 @@ type MondayTime struct {
 }
 
 // NewModel creates a new TUI model with the given client and starting Monday.
-func NewModel(client odoo.Client, monday MondayTime, limits config.HoursLimits, bundesland string, keys config.KeysConfig) Model {
+func NewModel(client odoo.Client, monday MondayTime, limits config.HoursLimits, bundesland string, keys config.KeysConfig, companyColors map[string]string) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	km := DefaultKeyMap()
@@ -127,15 +129,16 @@ func NewModel(client odoo.Client, monday MondayTime, limits config.HoursLimits, 
 		km = ApplyKeysConfig(km, keys)
 	}
 	return Model{
-		state:      stateLoading,
-		client:     client,
-		monday:     monday,
-		limits:     limits,
-		bundesland: bundesland,
-		holidays:   BuildHolidayMap(monday.Year(), bundesland),
-		spinner:    s,
-		help:       help.New(),
-		keys:       km,
+		state:         stateLoading,
+		client:        client,
+		monday:        monday,
+		limits:        limits,
+		bundesland:    bundesland,
+		holidays:      BuildHolidayMap(monday.Year(), bundesland),
+		companyColors: companyColors,
+		spinner:       s,
+		help:          help.New(),
+		keys:          km,
 	}
 }
 
@@ -762,7 +765,7 @@ func (m Model) View() tea.View {
 			sunday.Format("Mon 02 Jan 2006"),
 			loadingIndicator,
 			clockStatus)
-		grid := RenderGrid(m.grid, m.cursor[0], m.cursor[1], m.width-4, m.limits, m.weekHols)
+		grid := RenderGrid(m.grid, m.cursor[0], m.cursor[1], m.width-4, m.limits, m.weekHols, m.companyColors)
 
 		helpView := m.help.View(m.keys)
 		s = "\n" + title + grid + "\n  " + helpView + "\n"
@@ -773,10 +776,10 @@ func (m Model) View() tea.View {
 			edit := renderEditForm(row, day, m.editHours, m.editDesc, m.editFocus, m.editErr, m.width, m.editIsNew)
 			s = RenderDetailOverlay(s, edit, m.width, m.height)
 		} else if m.state == stateDetail && m.cursor[0] < len(m.grid.Rows) {
-			detail := RenderDetail(m.grid.Rows[m.cursor[0]], m.cursor[1], m.monday.Time, m.detailCursor, m.width)
+			detail := RenderDetail(m.grid.Rows[m.cursor[0]], m.cursor[1], m.monday.Time, m.detailCursor, m.width, m.companyColors)
 			s = RenderDetailOverlay(s, detail, m.width, m.height)
 		} else if m.state == stateSearch {
-			search := renderSearchOverlay(m.searchInput, m.searchFiltered, m.searchCursor, m.searchSub, m.searchUseFilter, m.searchErr, m.spinner, m.width, m.height)
+			search := renderSearchOverlay(m.searchInput, m.searchFiltered, m.searchCursor, m.searchSub, m.searchUseFilter, m.searchErr, m.spinner, m.width, m.height, m.companyColors)
 			s = RenderDetailOverlay(s, search, m.width, m.height)
 		}
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -78,7 +78,7 @@ func (c *mockClient) AttendanceStatus() (*odoo.AttendanceStatus, error) { return
 func newTestModel(entries []odoo.TimesheetEntry, err error) Model {
 	client := &mockClient{entries: entries, err: err}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
-	return NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil)
+	return NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
 }
 
 func TestModel_LoadedTransitionsToGrid(t *testing.T) {
@@ -314,7 +314,7 @@ func TestModel_WindowSizeMsg(t *testing.T) {
 func newDetailModel(entries []odoo.TimesheetEntry) Model {
 	client := &mockClient{entries: entries}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
-	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil)
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
 	m.state = stateGrid
 	m.grid = BuildWeekGrid(entries, mon.Time)
 	m.cursor = [2]int{0, 0}
@@ -449,7 +449,7 @@ func TestModel_EditSubmitSuccess(t *testing.T) {
 	}
 	client := &mockClient{entries: entries}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
-	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil)
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
 	m.state = stateGrid
 	m.grid = BuildWeekGrid(entries, mon.Time)
 	m.cursor = [2]int{0, 0}
@@ -719,7 +719,7 @@ func TestModel_AddSubmitCallsCreate(t *testing.T) {
 	}
 	client := &mockClient{entries: entries, createdID: 99}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
-	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil)
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
 	m.state = stateGrid
 	m.grid = BuildWeekGrid(entries, mon.Time)
 	m.cursor = [2]int{0, 0}
@@ -885,7 +885,7 @@ func TestModel_DeleteEntryTriggersReload(t *testing.T) {
 	}
 	client := &mockClient{entries: entries}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
-	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil)
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
 	m.state = stateGrid
 	m.grid = BuildWeekGrid(entries, mon.Time)
 	m.cursor = [2]int{0, 0}
@@ -939,7 +939,7 @@ func TestModel_DeleteEntryNoEntriesNoop(t *testing.T) {
 	}
 	client := &mockClient{entries: entries}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
-	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil)
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
 	m.state = stateGrid
 	m.grid = BuildWeekGrid(entries, mon.Time)
 	m.cursor = [2]int{0, 0} // Monday — no entries
@@ -1022,7 +1022,7 @@ func newSearchModel(projects []odoo.ProjectInfo, tasks []odoo.TaskInfo) Model {
 		},
 	}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
-	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil)
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
 	m.state = stateGrid
 	m.grid = BuildWeekGrid(client.entries, mon.Time)
 	m.cursor = [2]int{0, 0}
@@ -1200,7 +1200,7 @@ func TestModel_SearchToggleFilter(t *testing.T) {
 		},
 	}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
-	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil)
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
 	m.state = stateGrid
 	m.grid = BuildWeekGrid(client.entries, mon.Time)
 	m.cursor = [2]int{0, 0}
@@ -1340,7 +1340,7 @@ func TestRenderSearchOverlay(t *testing.T) {
 		{Kind: "task", Name: "Task X", Extra: "Alpha"},
 	}
 
-	result := renderSearchOverlay(input, items, 0, searchReady, true, nil, spinner.New(), 80, 40)
+	result := renderSearchOverlay(input, items, 0, searchReady, true, nil, spinner.New(), 80, 40, nil)
 
 	if !strings.Contains(result, "Search (filtered)") {
 		t.Fatal("expected 'Search (filtered)' in output")
@@ -1361,7 +1361,7 @@ func TestRenderSearchOverlay(t *testing.T) {
 
 func TestRenderSearchOverlay_Unfiltered(t *testing.T) {
 	input := textinput.New()
-	result := renderSearchOverlay(input, nil, 0, searchReady, false, nil, spinner.New(), 80, 40)
+	result := renderSearchOverlay(input, nil, 0, searchReady, false, nil, spinner.New(), 80, 40, nil)
 
 	if !strings.Contains(result, "all") {
 		t.Fatal("expected 'all' in output for unfiltered mode")
@@ -1377,7 +1377,7 @@ func TestModel_DeleteEntryError(t *testing.T) {
 	}
 	client := &mockClient{entries: entries, deleteErr: errors.New("forbidden")}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
-	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil)
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
 	m.state = stateGrid
 	m.grid = BuildWeekGrid(entries, mon.Time)
 	m.cursor = [2]int{0, 0}

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -17,7 +17,8 @@ var dayNames = [7]string{"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"}
 
 // RenderGrid renders the weekly grid as a styled string.
 // holidays is a [7]string with holiday names per day (empty = no holiday).
-func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.HoursLimits, holidays [7]string) string {
+// companyColors maps company name to lipgloss color string for row label coloring.
+func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.HoursLimits, holidays [7]string, companyColors map[string]string) string {
 	minColWidth := 7
 	minLabelWidth := 20
 	maxLabelWidth := 40
@@ -91,7 +92,11 @@ func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.Ho
 		if len(label) > labelWidth {
 			label = label[:labelWidth-1] + "…"
 		}
-		line := fmt.Sprintf("%-*s  ", labelWidth, label)
+		styledLabel := fmt.Sprintf("%-*s", labelWidth, label)
+		if color, ok := companyColors[row.Company]; ok {
+			styledLabel = companyLabelStyle(color).Render(styledLabel)
+		}
+		line := styledLabel + "  "
 
 		var rowTotal float64
 		for d := 0; d < 7; d++ {
@@ -140,7 +145,7 @@ func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.Ho
 // Uses the bubbles table widget for the entries listing. The returned string is the
 // inner content (no border); use RenderDetailOverlay to composite it as a centered
 // overlay box on top of a background. detailCursor highlights the selected entry row.
-func RenderDetail(row GridRow, col int, monday time.Time, detailCursor int, width int) string {
+func RenderDetail(row GridRow, col int, monday time.Time, detailCursor int, width int, companyColors map[string]string) string {
 	// Inner content width is reduced by border (2) + padding (4).
 	innerWidth := width - 8
 	if innerWidth < 40 {
@@ -150,7 +155,11 @@ func RenderDetail(row GridRow, col int, monday time.Time, detailCursor int, widt
 	var b strings.Builder
 
 	day := monday.AddDate(0, 0, col)
-	header := fmt.Sprintf("%s — %s", row.Label, day.Format("Mon 02 Jan 2006"))
+	labelStr := row.Label
+	if color, ok := companyColors[row.Company]; ok {
+		labelStr = companyLabelStyle(color).Render(labelStr)
+	}
+	header := fmt.Sprintf("%s — %s", labelStr, day.Format("Mon 02 Jan 2006"))
 	b.WriteString(detailHeaderStyle.Render(header))
 	b.WriteString("\n")
 
@@ -326,7 +335,7 @@ func renderEditForm(row GridRow, day time.Time, hoursInput, descInput textinput.
 
 // renderSearchOverlay renders the search overlay content with a fixed size
 // derived from terminal dimensions so the overlay does not jump while typing.
-func renderSearchOverlay(input textinput.Model, items []searchItem, cursor int, sub searchSubState, useFilter bool, searchErr error, spin spinner.Model, width, height int) string {
+func renderSearchOverlay(input textinput.Model, items []searchItem, cursor int, sub searchSubState, useFilter bool, searchErr error, spin spinner.Model, width, height int, companyColors map[string]string) string {
 	// Fixed inner width: full terminal minus outer padding (8 each side),
 	// border (2), and box padding (4).
 	const outerPad = 8
@@ -428,7 +437,13 @@ func renderSearchOverlay(input textinput.Model, items []searchItem, cursor int, 
 
 			label := fmt.Sprintf("    [%s] %s", strings.ToUpper(item.Kind[:1]), item.Name)
 			if item.Extra != "" {
-				label += " — " + item.Extra
+				extra := item.Extra
+				if item.Kind == "project" {
+					if color, ok := companyColors[extra]; ok {
+						extra = companyLabelStyle(color).Render(extra)
+					}
+				}
+				label += " — " + extra
 			}
 
 			if i == cursor {

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -14,7 +14,7 @@ func TestRenderGrid_ContainsLabels(t *testing.T) {
 		{Date: "2026-03-03", Project: "Beta", Task: "QA", Hours: 2.5},
 	}
 	g := BuildWeekGrid(entries, monday(2026, 3, 2))
-	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{})
+	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil)
 
 	if !strings.Contains(out, "Acme / Dev") {
 		t.Error("output should contain 'Acme / Dev'")
@@ -32,7 +32,7 @@ func TestRenderGrid_ContainsLabels(t *testing.T) {
 
 func TestRenderGrid_EmptyGrid(t *testing.T) {
 	g := BuildWeekGrid(nil, monday(2026, 3, 2))
-	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{})
+	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil)
 
 	if !strings.Contains(out, "Project / Task") {
 		t.Error("output should contain header")
@@ -58,7 +58,7 @@ func TestRenderDetail_ShowsEntries(t *testing.T) {
 	row.Hours[0] = 3.5
 
 	mon := monday(2026, 3, 2)
-	out := RenderDetail(row, 0, mon, 0, 80)
+	out := RenderDetail(row, 0, mon, 0, 80, nil)
 
 	checks := []struct {
 		substr string
@@ -86,7 +86,7 @@ func TestRenderDetail_ShowsEntries(t *testing.T) {
 func TestRenderDetail_EmptyCell(t *testing.T) {
 	row := GridRow{Label: "Acme / Dev"}
 	mon := monday(2026, 3, 2)
-	out := RenderDetail(row, 0, mon, 0, 80)
+	out := RenderDetail(row, 0, mon, 0, 80, nil)
 
 	if !strings.Contains(out, "No entries") {
 		t.Error("output should indicate no entries")
@@ -107,7 +107,7 @@ func TestRenderDetailOverlay_CentersBox(t *testing.T) {
 	}
 	row.Hours[0] = 1.0
 
-	detail := RenderDetail(row, 0, monday(2026, 3, 2), 0, 60)
+	detail := RenderDetail(row, 0, monday(2026, 3, 2), 0, 60, nil)
 	result := RenderDetailOverlay(bg, detail, 60, 20)
 
 	// The overlay should contain the box border characters.
@@ -130,7 +130,7 @@ func TestRenderGrid_CorrectLineCount(t *testing.T) {
 		{Date: "2026-03-02", Project: "C", Task: "T3", Hours: 3.0},
 	}
 	g := BuildWeekGrid(entries, monday(2026, 3, 2))
-	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{})
+	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil)
 
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 	// header + sep + 3 data rows + sep + totals = 7

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -34,6 +34,11 @@ var (
 	searchSectionStyle  = lipgloss.NewStyle().Bold(true).Faint(true)
 )
 
+// companyLabelStyle returns a style with the given lipgloss color as foreground.
+func companyLabelStyle(color string) lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(color))
+}
+
 // hoursStyle returns the appropriate style based on daily total hours.
 func hoursStyle(total float64, limits config.HoursLimits) lipgloss.Style {
 	switch {

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ CLI tool for managing Odoo 17 timesheets and projects from the terminal, as well
 - Shows attendance state prominently
 - Color coded work hour day and week summaries with configurable limits
 - Configurable key bindings via `[keys]` section in config file
+- Company-based color coding for project/task labels via `[company_colors]` config
 - Add, edit and delete time entries
 - It's pretty fast
 
@@ -109,6 +110,10 @@ url = "https://odoo.example.com"
 database = "mydb"
 username = "admin"
 
+[company_colors]
+"My Company" = "5"       # purple/magenta
+"Partner Corp" = "2"     # green
+
 [models.project]
 extra_fields = [
   { name = "product_owner", field = "x_studio_productowner", type = "many2one" },
@@ -122,6 +127,18 @@ filters = [
   { field = "project_id.name", op = "=", value = "My Project" },
   { field = "stage_id.name", op = "=", value = "In Progress" },
 ]
+```
+
+### Company-based row colors
+
+Project/task labels in the TUI can be colored by company name using the
+`[company_colors]` section. Values are ANSI 256-color codes (as strings).
+Companies not listed use the default terminal color.
+
+```toml
+[company_colors]
+"digitalgedacht GmbH" = "5"    # purple/magenta
+"nexiles GmbH" = "2"           # green
 ```
 
 ### Custom fields per model


### PR DESCRIPTION
## Summary

- Fetch `company_id` from Odoo timesheet API and propagate through `TimesheetEntry` → `GridRow` → `HintRow`
- Add `[company_colors]` TOML config section mapping company names to ANSI 256-color strings
- Apply company colors to grid row labels, detail view headers, and search overlay project items
- Update README with new TUI feature and configuration docs

## Config example

```toml
[company_colors]
"digitalgedacht GmbH" = "5"    # purple/magenta
"nexiles GmbH" = "2"           # green
```

Unmapped companies use the default terminal color.

## Test plan

- [x] All existing tests pass (`mise run test`)
- [x] Lint clean (`mise run lint` — 0 issues)
- [x] New config tests: parse, no-section backward compat, merge overlay/nil
- [x] Updated all `NewModel`, `RenderGrid`, `RenderDetail`, `renderSearchOverlay` call sites in tests
- [ ] Manual: add `[company_colors]` to `.odoo-work-cli.toml`, run `tui`, verify colored labels
- [ ] Manual: remove `[company_colors]` section, verify no crash, default colors

Closes #2