### PR TITLE
Accept H:MM time format for hours input

### DIFF
--- a/cmd/odoo-work-cli/main.go
+++ b/cmd/odoo-work-cli/main.go
@@ -61,7 +61,7 @@ func init() {
 	entriesAddCmd.Flags().Int64Var(&addProjectID, "project-id", 0, "Odoo project ID (required)")
 	entriesAddCmd.Flags().Int64Var(&addTaskID, "task-id", 0, "Odoo task ID (optional)")
 	entriesAddCmd.Flags().StringVar(&addDate, "date", "", "entry date YYYY-MM-DD (defaults to today)")
-	entriesAddCmd.Flags().Float64Var(&addHours, "hours", 0, "hours worked (required, > 0)")
+	entriesAddCmd.Flags().StringVar(&addHours, "hours", "", "hours worked (e.g. 2.5 or 2:30)")
 	entriesAddCmd.Flags().StringVar(&addDescription, "description", "", "work description (required)")
 	_ = entriesAddCmd.MarkFlagRequired("hours")
 	_ = entriesAddCmd.MarkFlagRequired("description")
@@ -70,7 +70,7 @@ func init() {
 	entriesUpdateCmd.Flags().Int64Var(&updateProjectID, "project-id", 0, "Odoo project ID")
 	entriesUpdateCmd.Flags().Int64Var(&updateTaskID, "task-id", 0, "Odoo task ID")
 	entriesUpdateCmd.Flags().StringVar(&updateDate, "date", "", "entry date YYYY-MM-DD")
-	entriesUpdateCmd.Flags().Float64Var(&updateHours, "hours", 0, "hours worked (> 0)")
+	entriesUpdateCmd.Flags().StringVar(&updateHours, "hours", "", "hours worked (e.g. 2.5 or 2:30)")
 	entriesUpdateCmd.Flags().StringVar(&updateDescription, "description", "", "work description")
 
 	entriesCmd.AddCommand(entriesDeleteCmd)
@@ -331,14 +331,18 @@ var entriesCmd = &cobra.Command{
 }
 
 // buildTimesheetWriteParams constructs and validates TimesheetWriteParams from CLI flag values.
-// An empty date defaults to today.
-func buildTimesheetWriteParams(projectID, taskID int64, date, description string, hours float64) (odoo.TimesheetWriteParams, error) {
+// An empty date defaults to today. Hours accepts both decimal ("2.5") and H:MM ("2:30") formats.
+func buildTimesheetWriteParams(projectID, taskID int64, date, description, hoursStr string) (odoo.TimesheetWriteParams, error) {
 	if date == "" {
 		date = time.Now().Format("2006-01-02")
 	} else {
 		if _, err := time.Parse("2006-01-02", date); err != nil {
 			return odoo.TimesheetWriteParams{}, fmt.Errorf("invalid date %q: expected YYYY-MM-DD", date)
 		}
+	}
+	hours, err := tui.ParseHours(hoursStr)
+	if err != nil {
+		return odoo.TimesheetWriteParams{}, err
 	}
 	p := odoo.TimesheetWriteParams{
 		ProjectID: projectID,
@@ -357,7 +361,7 @@ var (
 	addProjectID   int64
 	addTaskID      int64
 	addDate        string
-	addHours       float64
+	addHours       string
 	addDescription string
 )
 
@@ -406,7 +410,7 @@ var (
 	updateProjectID   int64
 	updateTaskID      int64
 	updateDate        string
-	updateHours       float64
+	updateHours       string
 	updateDescription string
 )
 
@@ -427,10 +431,11 @@ func buildUpdateFields(cmd *cobra.Command) (map[string]interface{}, error) {
 		fields["date"] = updateDate
 	}
 	if cmd.Flags().Changed("hours") {
-		if updateHours <= 0 {
-			return nil, fmt.Errorf("hours must be greater than zero")
+		h, err := tui.ParseHours(updateHours)
+		if err != nil {
+			return nil, err
 		}
-		fields["unit_amount"] = updateHours
+		fields["unit_amount"] = h
 	}
 	if cmd.Flags().Changed("description") {
 		if updateDescription == "" {

--- a/cmd/odoo-work-cli/main_test.go
+++ b/cmd/odoo-work-cli/main_test.go
@@ -120,37 +120,49 @@ func TestBuildTimesheetWriteParams(t *testing.T) {
 		taskID      int64
 		date        string
 		description string
-		hours       float64
+		hours       string
+		wantHours   float64
 		wantErr     bool
 		wantMsg     string
 	}{
 		{
-			name:        "valid all fields",
+			name:        "valid all fields decimal",
 			projectID:   42,
 			taskID:      7,
 			date:        "2026-03-09",
 			description: "coding",
-			hours:       2.5,
+			hours:       "2.5",
+			wantHours:   2.5,
+		},
+		{
+			name:        "valid H:MM format",
+			projectID:   42,
+			date:        "2026-03-09",
+			description: "coding",
+			hours:       "2:30",
+			wantHours:   2.5,
 		},
 		{
 			name:        "valid without task",
 			projectID:   42,
 			date:        "2026-03-09",
 			description: "coding",
-			hours:       2.5,
+			hours:       "2.5",
+			wantHours:   2.5,
 		},
 		{
 			name:        "valid with only task ID",
 			taskID:      10,
 			date:        "2026-03-09",
 			description: "coding",
-			hours:       1.0,
+			hours:       "1",
+			wantHours:   1.0,
 		},
 		{
 			name:        "missing both project and task ID",
 			date:        "2026-03-09",
 			description: "coding",
-			hours:       1.0,
+			hours:       "1",
 			wantErr:     true,
 			wantMsg:     "project ID or task ID is required",
 		},
@@ -158,14 +170,15 @@ func TestBuildTimesheetWriteParams(t *testing.T) {
 			name:        "empty date defaults to today",
 			projectID:   42,
 			description: "coding",
-			hours:       1.0,
+			hours:       "1",
+			wantHours:   1.0,
 		},
 		{
 			name:        "invalid date format",
 			projectID:   42,
 			date:        "09/03/2026",
 			description: "coding",
-			hours:       1.0,
+			hours:       "1",
 			wantErr:     true,
 			wantMsg:     `invalid date "09/03/2026": expected YYYY-MM-DD`,
 		},
@@ -173,7 +186,7 @@ func TestBuildTimesheetWriteParams(t *testing.T) {
 			name:      "missing description",
 			projectID: 42,
 			date:      "2026-03-09",
-			hours:     1.0,
+			hours:     "1",
 			wantErr:   true,
 			wantMsg:   "description is required",
 		},
@@ -182,7 +195,7 @@ func TestBuildTimesheetWriteParams(t *testing.T) {
 			projectID:   42,
 			date:        "2026-03-09",
 			description: "coding",
-			hours:       0,
+			hours:       "0",
 			wantErr:     true,
 			wantMsg:     "hours must be greater than zero",
 		},
@@ -191,7 +204,7 @@ func TestBuildTimesheetWriteParams(t *testing.T) {
 			projectID:   42,
 			date:        "2026-03-09",
 			description: "coding",
-			hours:       -1.0,
+			hours:       "-1",
 			wantErr:     true,
 			wantMsg:     "hours must be greater than zero",
 		},
@@ -230,8 +243,8 @@ func TestBuildTimesheetWriteParams(t *testing.T) {
 			if params.Name != tt.description {
 				t.Errorf("Name = %q, want %q", params.Name, tt.description)
 			}
-			if params.Hours != tt.hours {
-				t.Errorf("Hours = %f, want %f", params.Hours, tt.hours)
+			if params.Hours != tt.wantHours {
+				t.Errorf("Hours = %f, want %f", params.Hours, tt.wantHours)
 			}
 		})
 	}
@@ -263,6 +276,11 @@ func TestBuildUpdateFields(t *testing.T) {
 			name:       "single field project-id",
 			flags:      []string{"--project-id", "42"},
 			wantFields: []string{"project_id"},
+		},
+		{
+			name:       "hours H:MM format",
+			flags:      []string{"--hours", "1:30"},
+			wantFields: []string{"unit_amount"},
 		},
 		{
 			name:       "multiple fields",
@@ -301,12 +319,11 @@ func TestBuildUpdateFields(t *testing.T) {
 			// Create a fresh command with the same flags as entriesUpdateCmd.
 			cmd := &cobra.Command{Use: "test"}
 			var pID, tID int64
-			var date, desc string
-			var hours float64
+			var date, desc, hours string
 			cmd.Flags().Int64Var(&pID, "project-id", 0, "")
 			cmd.Flags().Int64Var(&tID, "task-id", 0, "")
 			cmd.Flags().StringVar(&date, "date", "", "")
-			cmd.Flags().Float64Var(&hours, "hours", 0, "")
+			cmd.Flags().StringVar(&hours, "hours", "", "")
 			cmd.Flags().StringVar(&desc, "description", "", "")
 
 			err := cmd.ParseFlags(tt.flags)

--- a/internal/tui/grid.go
+++ b/internal/tui/grid.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/seletz/odoo-work-cli/internal/odoo"
@@ -195,6 +197,43 @@ func ParseWeekMonday(week string) (time.Time, error) {
 	}
 	monday1 := jan4.AddDate(0, 0, -int(weekday-1))
 	return monday1.AddDate(0, 0, (isoWeek-1)*7), nil
+}
+
+// ParseHours parses a duration string in either H:MM or decimal format.
+// Returns an error for empty strings, negative values, zero, and invalid formats.
+func ParseHours(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("hours must be a positive number (e.g. 1.5 or 1:30)")
+	}
+
+	var hours float64
+	if strings.Contains(s, ":") {
+		parts := strings.SplitN(s, ":", 2)
+		if parts[0] == "" || parts[1] == "" {
+			return 0, fmt.Errorf("invalid time format %q: expected H:MM", s)
+		}
+		h, err := strconv.Atoi(parts[0])
+		if err != nil || h < 0 {
+			return 0, fmt.Errorf("invalid time format %q: expected H:MM", s)
+		}
+		m, err := strconv.Atoi(parts[1])
+		if err != nil || m < 0 || m > 59 {
+			return 0, fmt.Errorf("invalid time format %q: minutes must be 0-59", s)
+		}
+		hours = float64(h) + float64(m)/60.0
+	} else {
+		var err error
+		hours, err = strconv.ParseFloat(s, 64)
+		if err != nil {
+			return 0, fmt.Errorf("hours must be a positive number (e.g. 1.5 or 1:30)")
+		}
+	}
+
+	if hours <= 0 {
+		return 0, fmt.Errorf("hours must be greater than zero")
+	}
+	return hours, nil
 }
 
 // FormatHours formats a duration in decimal hours as "H:MM".

--- a/internal/tui/grid_test.go
+++ b/internal/tui/grid_test.go
@@ -316,6 +316,51 @@ func TestGridRow_ProjectTaskIDs_EntriesOverrideHint(t *testing.T) {
 	}
 }
 
+func TestParseHours(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    float64
+		wantErr bool
+	}{
+		// H:MM format
+		{"2:30", 2.5, false},
+		{"1:00", 1.0, false},
+		{"0:45", 0.75, false},
+		{"8:15", 8.25, false},
+		// decimal format
+		{"2.5", 2.5, false},
+		{"0.75", 0.75, false},
+		{"1", 1.0, false},
+		// error cases
+		{"", 0, true},
+		{"abc", 0, true},
+		{"-1", 0, true},
+		{"-1:30", 0, true},
+		{"2:60", 0, true},
+		{":30", 0, true},
+		{"2:", 0, true},
+		{"0", 0, true},
+		{"0:00", 0, true},
+		{"0.0", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseHours(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("ParseHours(%q) = %v, want error", tt.input, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseHours(%q) unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseHours(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestFormatHours(t *testing.T) {
 	tests := []struct {
 		input float64

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -405,7 +405,7 @@ func (m Model) enterEdit() (tea.Model, tea.Cmd) {
 	m.editHours = textinput.New()
 	m.editHours.SetValue(formatDecimalHours(entry.Hours))
 	m.editHours.SetWidth(10)
-	m.editHours.Placeholder = "0.0"
+	m.editHours.Placeholder = "1.5 or 1:30"
 	cmd := m.editHours.Focus()
 
 	m.editDesc = textinput.New()
@@ -427,7 +427,7 @@ func (m Model) enterAdd() (tea.Model, tea.Cmd) {
 
 	m.editHours = textinput.New()
 	m.editHours.SetWidth(10)
-	m.editHours.Placeholder = "0.0"
+	m.editHours.Placeholder = "1.5 or 1:30"
 	cmd := m.editHours.Focus()
 
 	m.editDesc = textinput.New()
@@ -476,9 +476,9 @@ func (m Model) updateEdit(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 // submitEdit validates and saves the edit.
 func (m Model) submitEdit() (tea.Model, tea.Cmd) {
-	hours, err := strconv.ParseFloat(strings.TrimSpace(m.editHours.Value()), 64)
-	if err != nil || hours <= 0 {
-		m.editErr = fmt.Errorf("hours must be a positive number")
+	hours, err := ParseHours(m.editHours.Value())
+	if err != nil {
+		m.editErr = err
 		return m, nil
 	}
 	desc := strings.TrimSpace(m.editDesc.Value())

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ CLI tool for managing Odoo 17 timesheets and projects from the terminal, as well
 - Configurable key bindings via `[keys]` section in config file
 - Company-based color coding for project/task labels via `[company_colors]` config
 - Add, edit and delete time entries
+- Hours input accepts both `H:MM` (e.g. `1:30`) and decimal (e.g. `1.5`) formats
 - It's pretty fast
 
 ## Usage
@@ -40,8 +41,8 @@ Commands:
 | `tasks [project-id]`                                     | List Odoo tasks, optionally filtered by project ID                                                                  |
 | `timesheets [--week YYYY-Www]`                           | List timesheets for a week (defaults to current week)                                                               |
 | `entries [--week\|--date] [--project\|--task\|--status]` | List individual timesheet entries with full detail (description, hours, validation status)                          |
-| `entries add --project-id N --hours H --description "…"` | Create a new timesheet entry (date defaults to today, task-id optional)                                             |
-| `entries update ID [--hours H] [--description "…"] …`    | Partially update a timesheet entry (only set flags are sent)                                                        |
+| `entries add --project-id N --hours H --description "…"` | Create a new timesheet entry (hours: `2.5` or `2:30`, date defaults to today, task-id optional)                     |
+| `entries update ID [--hours H] [--description "…"] …`    | Partially update a timesheet entry (hours: `2.5` or `2:30`, only set flags are sent)                                |
 | `entries delete ID`                                      | Delete a timesheet entry by ID                                                                                      |
 | `clock in`                                               | Clock in (start attendance period)                                                                                  |
 | `clock out`                                              | Clock out (end attendance period, shows duration)                                                                   |
@@ -65,9 +66,9 @@ Examples:
 ./odoo-work-cli entries --week 2026-W10
 ./odoo-work-cli entries --date 2026-03-02
 ./odoo-work-cli entries --project "Acme" --status draft
-./odoo-work-cli entries add --project-id 42 --hours 2.5 --description "Dev work"
+./odoo-work-cli entries add --project-id 42 --hours 2:30 --description "Dev work"
 ./odoo-work-cli entries add --project-id 42 --task-id 10 --date 2026-03-09 --hours 1.5 --description "Code review"
-./odoo-work-cli entries update 100 --hours 3.0
+./odoo-work-cli entries update 100 --hours 1:15
 ./odoo-work-cli entries update 100 --description "Updated description" --hours 2.5
 ./odoo-work-cli entries delete 100
 ./odoo-work-cli clock in


### PR DESCRIPTION
## Summary

- Add `ParseHours` utility that accepts both `H:MM` (e.g. `2:30` → 2.5) and decimal (e.g. `2.5`) formats
- Wire into TUI edit form (placeholder updated to `1.5 or 1:30`)
- Wire into CLI `--hours` flags for `entries add` and `entries update` commands
- Table-driven tests with 18 cases covering both formats and edge cases

## Test plan

- [x] `mise run test` — all tests pass
- [x] `mise run lint` — 0 issues
- [x] TUI: edit an entry, type `1:30` in hours field → saves as 1.5h
- [x] CLI: `entries add --project-id X --hours 2:30 --description "test"` → creates 2.5h entry
- [x] CLI: `entries update ID --hours 1:15` → updates to 1.25h
- [x] Decimal format still works everywhere (`2.5`, `0.75`)

Closes #5