### PR TITLE
Add help overlay with grouped key bindings

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -25,6 +25,7 @@ const (
 	stateError
 	stateEdit
 	stateSearch
+	stateHelp
 )
 
 type searchSubState int
@@ -103,6 +104,8 @@ type Model struct {
 	editFocus    int             // 0=hours, 1=description
 	editErr      error           // last edit error
 	editIsNew    bool            // true = creating new entry, false = editing existing
+
+	helpPrevState uiState // state to return to when exiting help
 
 	companyColors map[string]string // company name → lipgloss color
 
@@ -272,6 +275,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyPressMsg:
+		// In help state, only Esc/q/? dismiss the overlay.
+		if m.state == stateHelp {
+			switch {
+			case key.Matches(msg, m.keys.Back), key.Matches(msg, m.keys.Quit), key.Matches(msg, m.keys.Help):
+				m.state = m.helpPrevState
+			}
+			return m, nil
+		}
 		// In search state, forward keys to search handler.
 		if m.state == stateSearch {
 			return m.updateSearch(msg)
@@ -286,7 +297,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case key.Matches(msg, m.keys.Help):
-			m.help.ShowAll = !m.help.ShowAll
+			m.helpPrevState = m.state
+			m.state = stateHelp
 			return m, nil
 
 		case key.Matches(msg, m.keys.Refresh):
@@ -748,7 +760,7 @@ func (m Model) View() tea.View {
 	case stateError:
 		s = fmt.Sprintf("\n  Error: %s\n\n  Press 'r' to retry or 'q' to quit.\n\n", m.err)
 
-	case stateGrid, stateDetail, stateEdit, stateSearch:
+	case stateGrid, stateDetail, stateEdit, stateSearch, stateHelp:
 		sunday := m.monday.AddDate(0, 0, 6)
 		loadingIndicator := ""
 		if m.loading {
@@ -781,6 +793,9 @@ func (m Model) View() tea.View {
 		} else if m.state == stateSearch {
 			search := renderSearchOverlay(m.searchInput, m.searchFiltered, m.searchCursor, m.searchSub, m.searchUseFilter, m.searchErr, m.spinner, m.width, m.height, m.companyColors)
 			s = RenderDetailOverlay(s, search, m.width, m.height)
+		} else if m.state == stateHelp {
+			helpContent := renderHelpOverlay(m.keys, m.width, m.height)
+			s = RenderDetailOverlay(s, helpContent, m.width, m.height)
 		}
 	}
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1399,3 +1399,125 @@ func TestModel_DeleteEntryError(t *testing.T) {
 		t.Fatalf("expected stateError on delete failure, got %v", um.state)
 	}
 }
+
+func TestHelpOverlayStateTransitions(t *testing.T) {
+	mon := MondayTime{time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)}
+	client := &mockClient{}
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+	m.grid = BuildWeekGrid(nil, mon.Time)
+	m.width = 120
+	m.height = 40
+
+	tests := []struct {
+		name          string
+		startState    uiState
+		key           tea.KeyPressMsg
+		wantState     uiState
+		wantPrevState uiState
+	}{
+		{
+			name:          "? from grid enters help",
+			startState:    stateGrid,
+			key:           tea.KeyPressMsg{Code: '?'},
+			wantState:     stateHelp,
+			wantPrevState: stateGrid,
+		},
+		{
+			name:          "? from detail enters help",
+			startState:    stateDetail,
+			key:           tea.KeyPressMsg{Code: '?'},
+			wantState:     stateHelp,
+			wantPrevState: stateDetail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m.state = tt.startState
+			updated, _ := m.Update(tt.key)
+			um := updated.(Model)
+			if um.state != tt.wantState {
+				t.Errorf("state = %v, want %v", um.state, tt.wantState)
+			}
+			if um.helpPrevState != tt.wantPrevState {
+				t.Errorf("helpPrevState = %v, want %v", um.helpPrevState, tt.wantPrevState)
+			}
+		})
+	}
+}
+
+func TestHelpOverlayDismiss(t *testing.T) {
+	mon := MondayTime{time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)}
+	client := &mockClient{}
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+	m.grid = BuildWeekGrid(nil, mon.Time)
+	m.width = 120
+	m.height = 40
+
+	tests := []struct {
+		name       string
+		prevState  uiState
+		key        tea.KeyPressMsg
+		wantReturn uiState
+	}{
+		{
+			name:       "Esc returns to grid",
+			prevState:  stateGrid,
+			key:        tea.KeyPressMsg{Code: tea.KeyEscape},
+			wantReturn: stateGrid,
+		},
+		{
+			name:       "Esc returns to detail",
+			prevState:  stateDetail,
+			key:        tea.KeyPressMsg{Code: tea.KeyEscape},
+			wantReturn: stateDetail,
+		},
+		{
+			name:       "? toggles back to grid",
+			prevState:  stateGrid,
+			key:        tea.KeyPressMsg{Code: '?'},
+			wantReturn: stateGrid,
+		},
+		{
+			name:       "q returns to previous state",
+			prevState:  stateGrid,
+			key:        tea.KeyPressMsg{Code: 'q'},
+			wantReturn: stateGrid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m.state = stateHelp
+			m.helpPrevState = tt.prevState
+			updated, _ := m.Update(tt.key)
+			um := updated.(Model)
+			if um.state != tt.wantReturn {
+				t.Errorf("state = %v, want %v", um.state, tt.wantReturn)
+			}
+		})
+	}
+}
+
+func TestHelpOverlayRendered(t *testing.T) {
+	mon := MondayTime{time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)}
+	client := &mockClient{}
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+	m.grid = BuildWeekGrid(nil, mon.Time)
+	m.width = 120
+	m.height = 40
+	m.state = stateHelp
+	m.helpPrevState = stateGrid
+
+	view := m.View()
+	// The help overlay should contain "Key Bindings" header and section headers.
+	if !strings.Contains(view.Content, "Key Bindings") {
+		t.Error("help overlay should contain 'Key Bindings' header")
+	}
+	if !strings.Contains(view.Content, "Navigation") {
+		t.Error("help overlay should contain 'Navigation' section")
+	}
+	if !strings.Contains(view.Content, "Global") {
+		t.Error("help overlay should contain 'Global' section")
+	}
+}

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -470,6 +470,84 @@ func renderSearchOverlay(input textinput.Model, items []searchItem, cursor int, 
 	return b.String()
 }
 
+// renderHelpOverlay renders a help overlay with key bindings grouped by context.
+func renderHelpOverlay(km KeyMap, width, height int) string {
+	const outerPad = 8
+	innerWidth := width - 2*outerPad - 6
+	if innerWidth < 40 {
+		innerWidth = 40
+	}
+
+	padLine := func(s string) string {
+		runes := []rune(s)
+		if len(runes) < innerWidth {
+			return s + strings.Repeat(" ", innerWidth-len(runes))
+		}
+		return s
+	}
+
+	type binding struct {
+		key  string
+		desc string
+	}
+	type section struct {
+		name     string
+		bindings []binding
+	}
+
+	sections := []section{
+		{"Navigation", []binding{
+			{km.Up.Help().Key, km.Up.Help().Desc},
+			{km.Down.Help().Key, km.Down.Help().Desc},
+			{km.NextCol.Help().Key, km.NextCol.Help().Desc},
+			{km.PrevCol.Help().Key, km.PrevCol.Help().Desc},
+		}},
+		{"Grid View", []binding{
+			{km.Enter.Help().Key, km.Enter.Help().Desc},
+			{km.Search.Help().Key, km.Search.Help().Desc},
+		}},
+		{"Detail View", []binding{
+			{km.Edit.Help().Key, km.Edit.Help().Desc},
+			{km.Add.Help().Key, km.Add.Help().Desc},
+			{km.Delete.Help().Key, km.Delete.Help().Desc},
+		}},
+		{"Search", []binding{
+			{km.SearchToggle.Help().Key, km.SearchToggle.Help().Desc},
+		}},
+		{"Global", []binding{
+			{km.Left.Help().Key, km.Left.Help().Desc},
+			{km.Right.Help().Key, km.Right.Help().Desc},
+			{km.Back.Help().Key, km.Back.Help().Desc},
+			{km.Refresh.Help().Key, km.Refresh.Help().Desc},
+			{km.Help.Help().Key, km.Help.Help().Desc},
+			{km.Quit.Help().Key, km.Quit.Help().Desc},
+		}},
+	}
+
+	var b strings.Builder
+
+	b.WriteString(padLine("  " + detailHeaderStyle.Render("Key Bindings")))
+	b.WriteString("\n")
+
+	for _, sec := range sections {
+		b.WriteString(padLine(""))
+		b.WriteString("\n")
+		b.WriteString(padLine("  " + searchSectionStyle.Render(sec.name)))
+		b.WriteString("\n")
+		for _, bind := range sec.bindings {
+			line := fmt.Sprintf("    %-12s %s", bind.key, bind.desc)
+			b.WriteString(padLine(line))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString(padLine(""))
+	b.WriteString("\n")
+	b.WriteString(detailHintStyle.Render("  Press Esc or ? to close"))
+
+	return b.String()
+}
+
 // lipglossWidth returns the visual width of the widest line.
 func lipglossWidth(lines []string) int {
 	max := 0

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ CLI tool for managing Odoo 17 timesheets and projects from the terminal, as well
 - Company-based color coding for project/task labels via `[company_colors]` config
 - Add, edit and delete time entries
 - Hours input accepts both `H:MM` (e.g. `1:30`) and decimal (e.g. `1.5`) formats
+- Help overlay (`?` key) showing all key bindings grouped by context
 - It's pretty fast
 
 ## Usage


### PR DESCRIPTION
## Summary

- Adds a `?`-triggered help overlay showing all TUI key bindings grouped by context (Navigation, Grid View, Detail View, Search, Global)
- Overlay uses the existing `RenderDetailOverlay` compositing pattern with a two-column key/description layout
- Esc or `?` dismisses the overlay and returns to the previous view state

Closes #9

## Test plan

- [x] `mise run test` — all tests pass (3 new test functions with table-driven cases)
- [x] `mise run lint` — 0 issues
- [ ] TUI: press `?` in grid view → help overlay appears with grouped key bindings
- [ ] TUI: press `Esc` or `?` → overlay closes, returns to previous view
- [ ] TUI: press `?` in detail view → help overlay appears, Esc returns to detail
- [ ] TUI: bottom help bar still visible in grid view
- [ ] TUI: `?` does NOT trigger from edit or search states