### PR TITLE
Add config install subcommand (#11)

### DIFF
--- a/cmd/odoo-work-cli/main.go
+++ b/cmd/odoo-work-cli/main.go
@@ -56,6 +56,7 @@ func init() {
 	entriesCmd.Flags().StringVar(&entriesStatus, "status", "", "filter by validation status (e.g. draft, validated)")
 	tuiCmd.Flags().StringVar(&tuiWeek, "week", "", "ISO week (e.g. 2026-W10), defaults to current week")
 	configCmd.Flags().BoolVar(&configMerged, "merged", false, "print merged TOML config (password redacted)")
+	configCmd.AddCommand(configInstallCmd)
 
 	entriesCmd.AddCommand(entriesAddCmd)
 	entriesAddCmd.Flags().Int64Var(&addProjectID, "project-id", 0, "Odoo project ID (required)")
@@ -733,4 +734,42 @@ var configCmd = &cobra.Command{
 		fmt.Print(buf.String())
 		return nil
 	},
+}
+
+var configInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Create a default config file in the platform config directory",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path, err := config.DefaultConfigPath()
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("This will create a default config file at:\n  %s\n\n", path)
+
+		if !confirmPrompt("Continue?") {
+			fmt.Println("Aborted.")
+			return nil
+		}
+
+		if err := config.InstallConfig(path); err != nil {
+			return err
+		}
+
+		fmt.Printf("Config file created at: %s\n", path)
+		fmt.Println("Edit it to set your Odoo URL, database, and username.")
+		fmt.Println("Set ODOO_PASSWORD via environment variable (see .env.1p).")
+		return nil
+	},
+}
+
+// confirmPrompt prints msg and reads y/N from stdin.
+func confirmPrompt(msg string) bool {
+	fmt.Printf("%s [y/N] ", msg)
+	var response string
+	if _, err := fmt.Scanln(&response); err != nil {
+		return false
+	}
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes"
 }

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -1,0 +1,46 @@
+# odoo-work-cli configuration
+# See: https://github.com/seletz/odoo-work-cli
+
+# Odoo server URL
+url = "https://odoo.example.com"
+
+# Odoo database name
+database = "odoo"
+
+# Odoo username (login email)
+username = "user@example.com"
+
+# NOTE: password/API key must be set via ODOO_PASSWORD env var, not here.
+
+# German federal state for public holiday detection.
+# Valid values: Baden-Württemberg, Bayern, Berlin, Brandenburg, Bremen,
+#   Hamburg, Hessen, Mecklenburg-Vorpommern, Niedersachsen,
+#   Nordrhein-Westfalen, Rheinland-Pfalz, Saarland, Sachsen,
+#   Sachsen-Anhalt, Schleswig-Holstein, Thüringen
+bundesland = "Baden-Württemberg"
+
+# Work-hour thresholds for TUI color coding.
+[hours]
+daily_low = 6.0    # below this: yellow
+daily_high = 9.0   # above this: red
+weekly_low = 35.0  # below this: yellow
+weekly_high = 40.0 # above this: red
+
+# TUI key bindings (action = "key" or action = ["key1", "key2"]).
+# [keys]
+# quit = ["q", "ctrl+c"]
+# help = "?"
+
+# Company-name to color mapping for TUI labels.
+# [company_colors]
+# "My Company" = "#ff8800"
+
+# Per-model extra fields and default filters.
+# [models.timesheet]
+# extra_fields = [
+#   { name = "product_owner", field = "x_studio_productowner", type = "many2one" },
+# ]
+# [[models.timesheet.filters]]
+# field = "company_id.name"
+# op    = "="
+# value = "My Company"

--- a/internal/config/install.go
+++ b/internal/config/install.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//go:embed default_config.toml
+var defaultConfigTemplate []byte
+
+// DefaultConfigTemplate returns the embedded default configuration template.
+func DefaultConfigTemplate() []byte {
+	return defaultConfigTemplate
+}
+
+// InstallConfig writes the default configuration template to the given path.
+// Returns an error if the file already exists. Creates parent directories
+// as needed.
+func InstallConfig(path string) error {
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("config file already exists: %s", path)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, defaultConfigTemplate, 0o644); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/config/install_test.go
+++ b/internal/config/install_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestDefaultConfigTemplate_NonEmpty(t *testing.T) {
+	data := DefaultConfigTemplate()
+	if len(data) == 0 {
+		t.Fatal("DefaultConfigTemplate() returned empty data")
+	}
+}
+
+func TestDefaultConfigTemplate_ValidTOML(t *testing.T) {
+	data := DefaultConfigTemplate()
+	var raw map[string]interface{}
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("DefaultConfigTemplate() is not valid TOML: %v", err)
+	}
+}
+
+func TestDefaultConfigTemplate_NoPasswordField(t *testing.T) {
+	data := DefaultConfigTemplate()
+	var raw map[string]interface{}
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := raw["password"]; ok {
+		t.Fatal("DefaultConfigTemplate() must not contain a password field")
+	}
+}
+
+func TestInstallConfig_CreatesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	path, err := DefaultConfigPath()
+	if err != nil {
+		t.Fatalf("DefaultConfigPath: %v", err)
+	}
+
+	if err := InstallConfig(path); err != nil {
+		t.Fatalf("InstallConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading installed config: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("installed config file is empty")
+	}
+
+	// Verify it is valid TOML and loads without error.
+	if _, err := LoadFromTOML(path); err != nil {
+		t.Fatalf("LoadFromTOML on installed config: %v", err)
+	}
+}
+
+func TestInstallConfig_RefusesOverwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	path, err := DefaultConfigPath()
+	if err != nil {
+		t.Fatalf("DefaultConfigPath: %v", err)
+	}
+
+	// First install succeeds.
+	if err := InstallConfig(path); err != nil {
+		t.Fatalf("first InstallConfig: %v", err)
+	}
+
+	// Second install must fail.
+	err = InstallConfig(path)
+	if err == nil {
+		t.Fatal("expected error on second install, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected 'already exists' error, got: %v", err)
+	}
+}
+
+func TestInstallConfig_CreatesParentDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "deep", "nested", "config.toml")
+
+	if err := InstallConfig(path); err != nil {
+		t.Fatalf("InstallConfig with nested dirs: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("file not created at nested path: %v", err)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,9 @@ CLI tool for managing Odoo 17 timesheets and projects from the terminal, as well
 
 ## Features
 
-- **CLI:** ClI commands for scripting
+- **CLI:** CLI commands for scripting
 - **TUI:** Terminal UI for fast interactive usage
+- **Config bootstrapping:** `config install` creates a default config file
 
 ### TUI Features
 
@@ -51,6 +52,7 @@ Commands:
 | `fields <model>`                                         | Inspect field metadata for any Odoo model                                                                           |
 | `config`                                                 | Show discovered config file paths (merge order)                                                                     |
 | `config --merged`                                        | Print the fully merged TOML config (password omitted)                                                               |
+| `config install`                                         | Create a default config file at the platform config directory                                                       |
 
 Examples:
 
@@ -76,6 +78,7 @@ Examples:
 ./odoo-work-cli clock status
 ./odoo-work-cli config
 ./odoo-work-cli config --merged
+./odoo-work-cli config install
 ```
 
 ## Configuration
@@ -106,10 +109,22 @@ rejected.
 
 ### Config file example
 
+Run `odoo-work-cli config install` to create a default config file with all
+options documented. The generated file looks like:
+
 ```toml
 url = "https://odoo.example.com"
-database = "mydb"
-username = "admin"
+database = "odoo"
+username = "user@example.com"
+bundesland = "Baden-Württemberg"
+
+# NOTE: password/API key must be set via ODOO_PASSWORD env var, not here.
+
+[hours]
+daily_low = 6.0    # below this: yellow
+daily_high = 9.0   # above this: red
+weekly_low = 35.0  # below this: yellow
+weekly_high = 40.0 # above this: red
 
 [company_colors]
 "My Company" = "5"       # purple/magenta


### PR DESCRIPTION
## Summary

- Adds `config install` subcommand that bootstraps a default config file at the platform config directory (`$XDG_CONFIG_HOME/odoo-work-cli/config.toml`)
- Default config template is compiled into the binary via `go:embed` — well-commented with all config options (url, database, username, bundesland, hours, keys, company_colors, models)
- Refuses to overwrite an existing config file; prompts user for confirmation before writing
- Updates README with new command, usage example, and improved config example section

## Test plan

- [x] `TestDefaultConfigTemplate_NonEmpty` — embedded template is non-empty
- [x] `TestDefaultConfigTemplate_ValidTOML` — template parses as valid TOML
- [x] `TestDefaultConfigTemplate_NoPasswordField` — no password in template
- [x] `TestInstallConfig_CreatesFile` — writes file, loadable by `LoadFromTOML`
- [x] `TestInstallConfig_RefusesOverwrite` — second install returns error
- [x] `TestInstallConfig_CreatesParentDirs` — creates nested directories
- [x] `mise run test` — all tests pass
- [x] `mise run lint` — clean

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)