### PR TITLE
Fix TUI cursor to start on today's column (#17)

### DIFF
--- a/internal/tui/grid.go
+++ b/internal/tui/grid.go
@@ -199,6 +199,20 @@ func ParseWeekMonday(week string) (time.Time, error) {
 	return monday1.AddDate(0, 0, (isoWeek-1)*7), nil
 }
 
+// TodayColumn returns the column index (0=Mon .. 6=Sun) for the given time
+// relative to the week starting at monday. Returns 0 if now falls outside the
+// displayed week.
+func TodayColumn(monday, now time.Time) int {
+	// Truncate to date-only for comparison.
+	monDate := time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, monday.Location())
+	nowDate := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	offset := int(nowDate.Sub(monDate).Hours() / 24)
+	if offset < 0 || offset > 6 {
+		return 0
+	}
+	return offset
+}
+
 // ParseHours parses a duration string in either H:MM or decimal format.
 // Returns an error for empty strings, negative values, zero, and invalid formats.
 func ParseHours(s string) (float64, error) {

--- a/internal/tui/grid_test.go
+++ b/internal/tui/grid_test.go
@@ -361,6 +361,35 @@ func TestParseHours(t *testing.T) {
 	}
 }
 
+func TestTodayColumn(t *testing.T) {
+	// Monday 2026-03-02
+	mon := monday(2026, 3, 2)
+
+	tests := []struct {
+		name string
+		now  time.Time
+		want int
+	}{
+		{"monday", time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC), 0},
+		{"tuesday", time.Date(2026, 3, 3, 10, 0, 0, 0, time.UTC), 1},
+		{"wednesday", time.Date(2026, 3, 4, 10, 0, 0, 0, time.UTC), 2},
+		{"thursday", time.Date(2026, 3, 5, 10, 0, 0, 0, time.UTC), 3},
+		{"friday", time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC), 4},
+		{"saturday", time.Date(2026, 3, 7, 10, 0, 0, 0, time.UTC), 5},
+		{"sunday", time.Date(2026, 3, 8, 10, 0, 0, 0, time.UTC), 6},
+		{"previous week", time.Date(2026, 2, 28, 10, 0, 0, 0, time.UTC), 0},
+		{"next week", time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TodayColumn(mon, tt.now)
+			if got != tt.want {
+				t.Errorf("TodayColumn(%v, %v) = %d, want %d", mon, tt.now, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatHours(t *testing.T) {
 	tests := []struct {
 		input float64

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -203,7 +203,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Preserve detail state when reloading after edit save.
 		if m.state != stateDetail {
 			m.state = stateGrid
-			m.cursor = [2]int{0, 0}
+			m.cursor = [2]int{0, TodayColumn(m.monday.Time, time.Now())}
 		}
 		hints := HintLabelsFromEntries(msg.prevEntries)
 		m.grid = BuildWeekGridWithHints(msg.entries, m.monday.Time, hints)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -99,6 +100,47 @@ func TestModel_LoadedTransitionsToGrid(t *testing.T) {
 	}
 	if len(um.grid.Rows) != 1 {
 		t.Fatalf("expected 1 grid row, got %d", len(um.grid.Rows))
+	}
+}
+
+func TestModel_CursorOnTodayColumn(t *testing.T) {
+	// Use the current week so TodayColumn returns the real day offset.
+	now := time.Now()
+	year, week := now.ISOWeek()
+	mon, _ := ParseWeekMonday(fmt.Sprintf("%d-W%02d", year, week))
+	client := &mockClient{}
+	m := NewModel(client, MondayTime{Time: mon}, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+
+	msg := timesheetsLoadedMsg{
+		entries: []odoo.TimesheetEntry{
+			{Date: mon.Format("2006-01-02"), Project: "Acme", Task: "Dev", Hours: 1.0},
+		},
+	}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	wantCol := TodayColumn(mon, now)
+	if um.cursor[1] != wantCol {
+		t.Fatalf("expected cursor column %d (today), got %d", wantCol, um.cursor[1])
+	}
+}
+
+func TestModel_CursorResetToPastWeek(t *testing.T) {
+	// For a past week, TodayColumn returns 0 (today not in that week).
+	mon := time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC) // a past Monday
+	client := &mockClient{}
+	m := NewModel(client, MondayTime{Time: mon}, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+
+	msg := timesheetsLoadedMsg{
+		entries: []odoo.TimesheetEntry{
+			{Date: "2025-01-06", Project: "Acme", Task: "Dev", Hours: 1.0},
+		},
+	}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.cursor[1] != 0 {
+		t.Fatalf("expected cursor column 0 for past week, got %d", um.cursor[1])
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ CLI tool for managing Odoo 17 timesheets and projects from the terminal, as well
 - Add, edit and delete time entries
 - Hours input accepts both `H:MM` (e.g. `1:30`) and decimal (e.g. `1.5`) formats
 - Help overlay (`?` key) showing all key bindings grouped by context
+- Cursor starts on today's column when viewing the current week
 - It's pretty fast
 
 ## Usage


### PR DESCRIPTION
## Summary

- The TUI grid cursor always started on Monday (column 0) regardless of the current day
- Added `TodayColumn()` helper that computes the weekday offset relative to the displayed week's Monday
- When viewing the current week, the cursor now starts on today's column; for past/future weeks it defaults to Monday

Fixes #17

## Test plan

- [x] `TestTodayColumn` — table-driven tests for all 7 weekdays plus out-of-range dates
- [x] `TestModel_CursorOnTodayColumn` — model test verifying cursor lands on today's column for the current week
- [x] `TestModel_CursorResetToPastWeek` — model test verifying cursor defaults to Monday for past weeks
- [x] All existing tests pass (`mise run test`)
- [x] Lint clean (`mise run lint`)