### PR TITLE
Add Homebrew tap support via GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,96 +1,33 @@
 name: Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: write
 
 jobs:
-  build:
+  goreleaser:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: darwin
-            goarch: amd64
-            ext: tar.gz
-          - goos: darwin
-            goarch: arm64
-            ext: tar.gz
-          - goos: linux
-            goarch: amd64
-            ext: tar.gz
-          - goos: linux
-            goarch: arm64
-            ext: tar.gz
-          - goos: windows
-            goarch: amd64
-            ext: zip
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      - name: Build
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
         env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: "0"
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          BINARY="odoo-work-cli"
-          if [ "${{ matrix.goos }}" = "windows" ]; then
-            BINARY="odoo-work-cli.exe"
-          fi
-          go build -ldflags "-X github.com/seletz/odoo-work-cli/internal/version.Version=${TAG}" \
-            -o "${BINARY}" ./cmd/odoo-work-cli
-
-      - name: Package
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          BINARY="odoo-work-cli"
-          if [ "${{ matrix.goos }}" = "windows" ]; then
-            BINARY="odoo-work-cli.exe"
-          fi
-          ARCHIVE="odoo-work-cli-${TAG}-${{ matrix.goos }}-${{ matrix.goarch }}"
-          if [ "${{ matrix.ext }}" = "tar.gz" ]; then
-            tar czf "${ARCHIVE}.tar.gz" "${BINARY}"
-          else
-            zip "${ARCHIVE}.zip" "${BINARY}"
-          fi
-
-      - name: Upload artifact
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          ARCHIVE="odoo-work-cli-${TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.ext }}"
-          gh release upload "$TAG" "$ARCHIVE" --repo "${{ github.repository }}"
-
-  checksums:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Download assets
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          gh release download "$TAG" --dir assets --repo "${{ github.repository }}"
-
-      - name: Generate checksums
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          cd assets
-          sha256sum * > "checksums-${TAG}.txt"
-
-      - name: Upload checksums
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          gh release upload "$TAG" "assets/checksums-${TAG}.txt" --repo "${{ github.repository }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 /odoo-work-cli
+/dist/
 *.exe
 *.dll
 *.so

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,66 @@
+version: 2
+
+project_name: odoo-work-cli
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: odoo-work-cli
+    main: ./cmd/odoo-work-cli
+    binary: odoo-work-cli
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X github.com/seletz/odoo-work-cli/internal/version.Version={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: "checksums-{{ .Tag }}.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  prerelease: auto
+
+homebrew_casks:
+  - name: odoo-work-cli
+    binaries:
+      - odoo-work-cli
+    repository:
+      owner: seletz
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Update {{ .ProjectName }} to {{ .Tag }}"
+    directory: Casks
+    homepage: "https://github.com/seletz/odoo-work-cli"
+    description: "CLI tool for managing Odoo 17 timesheets"
+    license: "MIT"

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,16 @@ module github.com/seletz/odoo-work-cli
 go 1.26.1
 
 require (
-	charm.land/bubbles/v2 v2.0.0 // indirect
-	charm.land/bubbletea/v2 v2.0.1 // indirect
-	charm.land/lipgloss/v2 v2.0.0 // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
+	charm.land/bubbles/v2 v2.0.0
+	charm.land/bubbletea/v2 v2.0.1
+	charm.land/lipgloss/v2 v2.0.0
+	github.com/BurntSushi/toml v1.6.0
+	github.com/skilld-labs/go-odoo v1.10.0
+	github.com/spf13/cobra v1.10.2
+	github.com/wlbr/feiertage v1.17.0
+)
+
+require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
@@ -22,10 +28,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/skilld-labs/go-odoo v1.10.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	github.com/wlbr/feiertage v1.17.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
+github.com/aymanbagabas/go-udiff v0.4.0 h1:TKnLPh7IbnizJIBKFWa9mKayRUBQ9Kh1BPCk6w2PnYM=
+github.com/aymanbagabas/go-udiff v0.4.0/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.14.1/go.mod h1:gi6uhQLMbTdeP0muCnrjHLeCUPyb70ujhnNlhOylAFc=
 github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
@@ -17,6 +19,8 @@ github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 h1:eyFRb
 github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8/go.mod h1:SQpCTRNBtzJkwku5ye4S3HEuthAlGy2n9VXZnWkEW98=
 github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF7ihZW8=
 github.com/charmbracelet/x/ansi v0.11.6/go.mod h1:2JNYLgQUsyqaiLovhU2Rv/pb8r6ydXKS3NIttu3VGZQ=
+github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
+github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f/go.mod h1:IfZAMTHB6XkZSeXUqriemErjAWCCzT0LwjKFYCZyw0I=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=
@@ -74,6 +78,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -112,6 +118,7 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ go = "latest"
 op = "latest"
 "go:github.com/golangci/golangci-lint/v2/cmd/golangci-lint" = "latest"
 gh = "latest"
+goreleaser = "latest"
 
 [tasks.build]
 description = "Build the CLI binary"
@@ -32,3 +33,11 @@ run = "gofmt -w ."
 [tasks.inject-env]
 description = "Inject secrets from 1Password into .env"
 run = "op inject -f -i .env.1p -o .env"
+
+[tasks.goreleaser-check]
+description = "Validate GoReleaser config"
+run = "goreleaser check"
+
+[tasks.goreleaser-snapshot]
+description = "Test GoReleaser build locally (no publish)"
+run = "goreleaser release --snapshot --clean"

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,26 @@ CLI tool for managing Odoo 17 timesheets and projects from the terminal, as well
 - Hours input accepts both `H:MM` (e.g. `1:30`) and decimal (e.g. `1.5`) formats
 - It's pretty fast
 
+## Installation
+
+### Homebrew (macOS / Linux)
+
+```bash
+brew install seletz/tap/odoo-work-cli
+```
+
+### From GitHub Releases
+
+Download the latest binary from
+[Releases](https://github.com/seletz/odoo-work-cli/releases) and place it on
+your `PATH`.
+
+### From Source
+
+```bash
+go install github.com/seletz/odoo-work-cli/cmd/odoo-work-cli@latest
+```
+
 ## Usage
 
 ### TUI
@@ -224,7 +244,8 @@ mise run lint
 
 ## Releasing
 
-Releases are managed via `mise run release` and built automatically by GitHub Actions.
+Releases are managed via `mise run release` and built by
+[GoReleaser](https://goreleaser.com/) in GitHub Actions.
 
 ### Creating a release
 
@@ -238,16 +259,20 @@ This will:
 2. Prompt for bump type (patch / minor / major)
 3. Create an annotated git tag
 4. Push the tag to origin
-5. Create a GitHub prerelease with auto-generated notes
 
-### CI build
-
-When a release is created, GitHub Actions automatically:
+GoReleaser then automatically:
 
 - Cross-compiles for macOS (amd64, arm64), Linux (amd64, arm64), and Windows (amd64)
 - Packages binaries as `.tar.gz` (Unix) or `.zip` (Windows)
-- Uploads all artifacts to the release
-- Generates a `checksums-<tag>.txt` with SHA-256 hashes
+- Creates a GitHub Release with all artifacts and SHA-256 checksums
+- Updates the [Homebrew tap](https://github.com/seletz/homebrew-tap) so `brew upgrade` picks up the new version
+
+### Local testing
+
+```bash
+mise run goreleaser-check       # validate .goreleaser.yml
+mise run goreleaser-snapshot    # full build without publishing
+```
 
 ### Version embedding
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -54,9 +54,6 @@ git tag -a "$NEXT" -m "Release $NEXT"
 echo "Pushing tag to origin..."
 git push origin "$NEXT"
 
-echo "Creating GitHub prerelease..."
-gh release create "$NEXT" --title "$NEXT" --generate-notes --prerelease
-
 echo ""
-echo "Done! Release $NEXT created as prerelease."
-echo "GitHub Actions will build and attach artifacts."
+echo "Done! Tag $NEXT pushed."
+echo "GoReleaser will build artifacts, create the GitHub release, and update the Homebrew tap."


### PR DESCRIPTION
## Summary

- Replace manual release workflow with GoReleaser v2 for automated cross-platform builds, GitHub Releases, and Homebrew cask updates
- Add `.goreleaser.yml` config targeting `seletz/homebrew-tap`
- Add installation section to README (Homebrew, GitHub Releases, from source)
- Add `goreleaser` to mise tools with `goreleaser-check` and `goreleaser-snapshot` tasks

## Test plan

- [x] `mise run goreleaser-check` passes
- [x] `mise run goreleaser-snapshot` builds all artifacts locally
- [ ] Cut a release tag and verify GitHub Actions creates the release with artifacts
- [ ] Verify `seletz/homebrew-tap` gets the cask file updated
- [ ] Verify `brew install seletz/tap/odoo-work-cli` works

Closes #14