### PR TITLE
Switch Homebrew from cask to formula (#23)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,10 +47,8 @@ changelog:
 release:
   prerelease: auto
 
-homebrew_casks:
+brews:
   - name: odoo-work-cli
-    binaries:
-      - odoo-work-cli
     repository:
       owner: seletz
       name: homebrew-tap
@@ -60,7 +58,7 @@ homebrew_casks:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "Update {{ .ProjectName }} to {{ .Tag }}"
-    directory: Casks
+    directory: Formula
     homepage: "https://github.com/seletz/odoo-work-cli"
     description: "CLI tool for managing Odoo 17 timesheets"
     license: "MIT"

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,8 @@ CLI tool for managing Odoo 17 timesheets and projects from the terminal, as well
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew install seletz/tap/odoo-work-cli
+brew tap seletz/tap
+brew install odoo-work-cli
 ```
 
 ### From GitHub Releases

--- a/readme.md
+++ b/readme.md
@@ -284,7 +284,7 @@ GoReleaser then automatically:
 - Cross-compiles for macOS (amd64, arm64), Linux (amd64, arm64), and Windows (amd64)
 - Packages binaries as `.tar.gz` (Unix) or `.zip` (Windows)
 - Creates a GitHub Release with all artifacts and SHA-256 checksums
-- Updates the [Homebrew tap](https://github.com/seletz/homebrew-tap) so `brew upgrade` picks up the new version
+- Updates the [Homebrew tap](https://github.com/seletz/homebrew-tap) formula so `brew upgrade` picks up the new version
 
 ### Local testing
 


### PR DESCRIPTION
## Summary
- Switch GoReleaser from `homebrew_casks` to `brews` (formula) to avoid macOS Gatekeeper quarantine on unsigned binaries
- Update README with explicit `brew tap` step in installation instructions
- The old cask in `Casks/` directory will be replaced by a formula in `Formula/` on next release

## Test plan
- [x] Run `mise run goreleaser-check` to validate config
- [x] After next release, verify `brew install seletz/tap/odoo-work-cli` installs without Gatekeeper issues
- [ ] Verify `odoo-work-cli --version` works without being killed

Fixes #23