### PR TITLE
Switch to homebrew_casks with quarantine stripping (#25)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,8 +47,10 @@ changelog:
 release:
   prerelease: auto
 
-brews:
+homebrew_casks:
   - name: odoo-work-cli
+    binaries:
+      - odoo-work-cli
     repository:
       owner: seletz
       name: homebrew-tap
@@ -58,7 +60,13 @@ brews:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "Update {{ .ProjectName }} to {{ .Tag }}"
-    directory: Formula
+    directory: Casks
     homepage: "https://github.com/seletz/odoo-work-cli"
     description: "CLI tool for managing Odoo 17 timesheets"
     license: "MIT"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/odoo-work-cli"]
+          end

--- a/readme.md
+++ b/readme.md
@@ -33,10 +33,8 @@ brew tap seletz/tap
 brew install odoo-work-cli
 ```
 
-> [!IMPORTANT]
-> **Upgrading from v0.2.1 or earlier?** The distribution changed from a
-> Homebrew cask to a formula. You need to untap and re-tap to pick up the new
-> format:
+> [!TIP]
+> If `brew upgrade` doesn't pick up a new version, untap and re-tap:
 >
 > ```bash
 > brew untap seletz/tap
@@ -296,7 +294,7 @@ GoReleaser then automatically:
 - Cross-compiles for macOS (amd64, arm64), Linux (amd64, arm64), and Windows (amd64)
 - Packages binaries as `.tar.gz` (Unix) or `.zip` (Windows)
 - Creates a GitHub Release with all artifacts and SHA-256 checksums
-- Updates the [Homebrew tap](https://github.com/seletz/homebrew-tap) formula so `brew upgrade` picks up the new version
+- Updates the [Homebrew tap](https://github.com/seletz/homebrew-tap) cask so `brew upgrade` picks up the new version
 
 ### Local testing
 


### PR DESCRIPTION
## Summary
- Switch from deprecated `brews` (formula) to `homebrew_casks` with a `post.install` hook that strips the macOS quarantine attribute via `xattr`
- Clean up README upgrade note (no more formula/cask migration language)
- GoReleaser config validates cleanly with no deprecation warnings

## Test plan
- [x] `goreleaser check` passes without warnings
- [ ] After release, verify `brew install seletz/tap/odoo-work-cli` works
- [ ] Verify `odoo-work-cli --version` runs without Gatekeeper killing it

Fixes #25