### PR TITLE
fix: clock in/out for non-admin users with 2FA #29

### DIFF
--- a/cmd/odoo-work-cli/main.go
+++ b/cmd/odoo-work-cli/main.go
@@ -91,7 +91,7 @@ func loadConfig() (*config.Config, error) {
 
 // newClient creates a new Odoo client from the merged config.
 func newClient(cfg *config.Config) (*odoo.XMLRPCClient, error) {
-	return odoo.NewXMLRPCClient(cfg.URL, cfg.Database, cfg.Username, cfg.Password, cfg.Models)
+	return odoo.NewXMLRPCClient(cfg.URL, cfg.Database, cfg.Username, cfg.Password, cfg.WebPassword, cfg.TOTPSecret, cfg.Models)
 }
 
 var projectsCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
@@ -27,6 +28,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.0 h1:TKnLPh7IbnizJIBKFWa9mKayRUBQ9Kh1BPCk6w2PnYM=
 github.com/aymanbagabas/go-udiff v0.4.0/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.14.1/go.mod h1:gi6uhQLMbTdeP0muCnrjHLeCUPyb70ujhnNlhOylAFc=
 github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
@@ -47,6 +49,8 @@ github.com/mattn/go-runewidth v0.0.20/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhg
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -60,6 +64,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,8 @@ type Config struct {
 	Database      string                 `toml:"database"`
 	Username      string                 `toml:"username"`
 	Password      string                 `toml:"-"`
+	WebPassword   string                 `toml:"-"`
+	TOTPSecret    string                 `toml:"-"`
 	OPSecrets     *OPSecrets             `toml:"op_secrets"`
 	Models        map[string]ModelConfig `toml:"models"`
 	Hours         HoursLimits            `toml:"hours"`
@@ -104,22 +106,25 @@ type Config struct {
 	CompanyColors map[string]string      `toml:"company_colors"` // company name → lipgloss color string
 }
 
-func (c *Config) OdooURL() string      { return c.URL }
-func (c *Config) OdooDatabase() string { return c.Database }
-func (c *Config) OdooUsername() string { return c.Username }
-func (c *Config) OdooPassword() string { return c.Password }
+func (c *Config) OdooURL() string         { return c.URL }
+func (c *Config) OdooDatabase() string    { return c.Database }
+func (c *Config) OdooUsername() string    { return c.Username }
+func (c *Config) OdooPassword() string    { return c.Password }
+func (c *Config) OdooWebPassword() string { return c.WebPassword }
 
 // LoadFromEnv reads configuration from environment variables.
 // It reads whatever env vars are set without requiring any.
 // Use Validate to check that all required fields are present.
 func LoadFromEnv() *Config {
 	return &Config{
-		URL:        os.Getenv("ODOO_URL"),
-		Database:   os.Getenv("ODOO_DATABASE"),
-		Username:   os.Getenv("ODOO_USERNAME"),
-		Password:   os.Getenv("ODOO_PASSWORD"),
-		Hours:      DefaultHoursLimits(),
-		Bundesland: DefaultBundesland,
+		URL:         os.Getenv("ODOO_URL"),
+		Database:    os.Getenv("ODOO_DATABASE"),
+		Username:    os.Getenv("ODOO_USERNAME"),
+		Password:    os.Getenv("ODOO_PASSWORD"),
+		WebPassword: os.Getenv("ODOO_WEB_PASSWORD"),
+		TOTPSecret:  os.Getenv("ODOO_TOTP_SECRET"),
+		Hours:       DefaultHoursLimits(),
+		Bundesland:  DefaultBundesland,
 	}
 }
 
@@ -197,6 +202,12 @@ func (c *Config) Merge(other *Config) {
 	if other.Password != "" {
 		c.Password = other.Password
 	}
+	if other.WebPassword != "" {
+		c.WebPassword = other.WebPassword
+	}
+	if other.TOTPSecret != "" {
+		c.TOTPSecret = other.TOTPSecret
+	}
 	if other.Bundesland != "" {
 		c.Bundesland = other.Bundesland
 	}
@@ -213,8 +224,14 @@ func (c *Config) Merge(other *Config) {
 		if other.OPSecrets.Username != "" {
 			c.OPSecrets.Username = other.OPSecrets.Username
 		}
+		if other.OPSecrets.APIKey != "" {
+			c.OPSecrets.APIKey = other.OPSecrets.APIKey
+		}
 		if other.OPSecrets.Password != "" {
 			c.OPSecrets.Password = other.OPSecrets.Password
+		}
+		if other.OPSecrets.TOTPSecret != "" {
+			c.OPSecrets.TOTPSecret = other.OPSecrets.TOTPSecret
 		}
 	}
 	if other.Hours.DailyLow != 0 {

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -19,7 +19,8 @@ username = "user@example.com"
 # url      = "op://vault/item/url"
 # database = "op://vault/item/database"
 # username = "op://vault/item/username"
-# password = "op://vault/item/api-key"
+# api-key  = "op://vault/item/api-key"       # Odoo API key (for XML-RPC)
+# password = "op://vault/item/password"       # Odoo login password (for clock in/out)
 
 # German federal state for public holiday detection.
 # Valid values: Baden-Württemberg, Bayern, Berlin, Brandenburg, Bremen,

--- a/internal/config/op.go
+++ b/internal/config/op.go
@@ -10,10 +10,12 @@ import (
 // OPSecrets holds 1Password vault references (op:// URIs) for config fields.
 // When present in the config file, these are resolved at runtime via the op CLI.
 type OPSecrets struct {
-	URL      string `toml:"url"`
-	Database string `toml:"database"`
-	Username string `toml:"username"`
-	Password string `toml:"password"`
+	URL        string `toml:"url"`
+	Database   string `toml:"database"`
+	Username   string `toml:"username"`
+	APIKey     string `toml:"api-key"`
+	Password   string `toml:"password"`
+	TOTPSecret string `toml:"totp_secret"`
 }
 
 // opInjectRunner abstracts the op inject call for testability.
@@ -56,7 +58,9 @@ func resolveOPSecrets(cfg *Config, runner opInjectRunner) error {
 		{"url", cfg.OPSecrets.URL, &cfg.URL},
 		{"database", cfg.OPSecrets.Database, &cfg.Database},
 		{"username", cfg.OPSecrets.Username, &cfg.Username},
-		{"password", cfg.OPSecrets.Password, &cfg.Password},
+		{"api-key", cfg.OPSecrets.APIKey, &cfg.Password},
+		{"password", cfg.OPSecrets.Password, &cfg.WebPassword},
+		{"totp_secret", cfg.OPSecrets.TOTPSecret, &cfg.TOTPSecret},
 	}
 
 	// Apply plain values directly; collect op:// refs for batch resolve.

--- a/internal/config/op_test.go
+++ b/internal/config/op_test.go
@@ -27,7 +27,8 @@ func TestResolveOPSecrets_AllFields(t *testing.T) {
 		"op://Work/odoo/url":      "https://odoo.example.com",
 		"op://Work/odoo/database": "mydb",
 		"op://Work/odoo/username": "admin@example.com",
-		"op://Work/odoo/api-key":  "secret-key",
+		"op://Work/odoo/api-key":  "secret-api-key",
+		"op://Work/odoo/password": "secret-password",
 	})
 
 	cfg := &Config{
@@ -35,7 +36,8 @@ func TestResolveOPSecrets_AllFields(t *testing.T) {
 			URL:      "op://Work/odoo/url",
 			Database: "op://Work/odoo/database",
 			Username: "op://Work/odoo/username",
-			Password: "op://Work/odoo/api-key",
+			APIKey:   "op://Work/odoo/api-key",
+			Password: "op://Work/odoo/password",
 		},
 	}
 
@@ -53,14 +55,17 @@ func TestResolveOPSecrets_AllFields(t *testing.T) {
 	if cfg.Username != "admin@example.com" {
 		t.Errorf("Username = %q, want %q", cfg.Username, "admin@example.com")
 	}
-	if cfg.Password != "secret-key" {
-		t.Errorf("Password = %q, want %q", cfg.Password, "secret-key")
+	if cfg.Password != "secret-api-key" {
+		t.Errorf("Password (API key) = %q, want %q", cfg.Password, "secret-api-key")
+	}
+	if cfg.WebPassword != "secret-password" {
+		t.Errorf("WebPassword = %q, want %q", cfg.WebPassword, "secret-password")
 	}
 }
 
-func TestResolveOPSecrets_PartialFields(t *testing.T) {
+func TestResolveOPSecrets_APIKeyOnly(t *testing.T) {
 	runner := fakeOPInjectRunner(map[string]string{
-		"op://Work/odoo/api-key": "secret-key",
+		"op://Work/odoo/api-key": "secret-api-key",
 	})
 
 	cfg := &Config{
@@ -68,7 +73,7 @@ func TestResolveOPSecrets_PartialFields(t *testing.T) {
 		Database: "existing-db",
 		Username: "existing-user",
 		OPSecrets: &OPSecrets{
-			Password: "op://Work/odoo/api-key",
+			APIKey: "op://Work/odoo/api-key",
 		},
 	}
 
@@ -80,8 +85,11 @@ func TestResolveOPSecrets_PartialFields(t *testing.T) {
 	if cfg.URL != "https://already-set.example.com" {
 		t.Errorf("URL = %q, want existing value", cfg.URL)
 	}
-	if cfg.Password != "secret-key" {
-		t.Errorf("Password = %q, want %q", cfg.Password, "secret-key")
+	if cfg.Password != "secret-api-key" {
+		t.Errorf("Password (API key) = %q, want %q", cfg.Password, "secret-api-key")
+	}
+	if cfg.WebPassword != "" {
+		t.Errorf("WebPassword = %q, want empty", cfg.WebPassword)
 	}
 }
 
@@ -107,7 +115,7 @@ func TestResolveOPSecrets_RunnerError(t *testing.T) {
 
 	cfg := &Config{
 		OPSecrets: &OPSecrets{
-			Password: "op://Work/odoo/api-key",
+			APIKey: "op://Work/odoo/api-key",
 		},
 	}
 
@@ -141,13 +149,13 @@ func TestResolveOPSecrets_OverwritesExistingFields(t *testing.T) {
 
 func TestResolveOPSecrets_PlainValues(t *testing.T) {
 	runner := fakeOPInjectRunner(map[string]string{
-		"op://Work/odoo/api-key": "secret-key",
+		"op://Work/odoo/api-key": "secret-api-key",
 	})
 
 	cfg := &Config{
 		OPSecrets: &OPSecrets{
 			Database: "odoo.170",
-			Password: "op://Work/odoo/api-key",
+			APIKey:   "op://Work/odoo/api-key",
 		},
 	}
 
@@ -159,8 +167,8 @@ func TestResolveOPSecrets_PlainValues(t *testing.T) {
 	if cfg.Database != "odoo.170" {
 		t.Errorf("Database = %q, want %q", cfg.Database, "odoo.170")
 	}
-	if cfg.Password != "secret-key" {
-		t.Errorf("Password = %q, want %q", cfg.Password, "secret-key")
+	if cfg.Password != "secret-api-key" {
+		t.Errorf("Password (API key) = %q, want %q", cfg.Password, "secret-api-key")
 	}
 }
 
@@ -191,6 +199,30 @@ func TestResolveOPSecrets_AllPlainValues(t *testing.T) {
 	}
 }
 
+func TestResolveOPSecrets_PasswordMapsToWebPassword(t *testing.T) {
+	runner := fakeOPInjectRunner(map[string]string{
+		"op://Work/odoo/password": "web-secret",
+	})
+
+	cfg := &Config{
+		OPSecrets: &OPSecrets{
+			Password: "op://Work/odoo/password",
+		},
+	}
+
+	err := resolveOPSecrets(cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.WebPassword != "web-secret" {
+		t.Errorf("WebPassword = %q, want %q", cfg.WebPassword, "web-secret")
+	}
+	if cfg.Password != "" {
+		t.Errorf("Password (API key) = %q, want empty", cfg.Password)
+	}
+}
+
 func TestLoadFromTOML_OPSecrets(t *testing.T) {
 	content := `
 url = "https://odoo.example.com"
@@ -198,7 +230,8 @@ database = "mydb"
 username = "admin"
 
 [op_secrets]
-password = "op://Work/odoo/api-key"
+api-key  = "op://Work/odoo/api-key"
+password = "op://Work/odoo/password"
 `
 	dir := t.TempDir()
 	path := dir + "/config.toml"
@@ -213,8 +246,11 @@ password = "op://Work/odoo/api-key"
 	if cfg.OPSecrets == nil {
 		t.Fatal("OPSecrets is nil")
 	}
-	if cfg.OPSecrets.Password != "op://Work/odoo/api-key" {
-		t.Errorf("OPSecrets.Password = %q, want %q", cfg.OPSecrets.Password, "op://Work/odoo/api-key")
+	if cfg.OPSecrets.APIKey != "op://Work/odoo/api-key" {
+		t.Errorf("OPSecrets.APIKey = %q, want %q", cfg.OPSecrets.APIKey, "op://Work/odoo/api-key")
+	}
+	if cfg.OPSecrets.Password != "op://Work/odoo/password" {
+		t.Errorf("OPSecrets.Password = %q, want %q", cfg.OPSecrets.Password, "op://Work/odoo/password")
 	}
 }
 
@@ -239,7 +275,8 @@ func TestMerge_OPSecrets(t *testing.T) {
 	base := &Config{}
 	overlay := &Config{
 		OPSecrets: &OPSecrets{
-			Password: "op://Work/odoo/api-key",
+			APIKey:   "op://Work/odoo/api-key",
+			Password: "op://Work/odoo/password",
 		},
 	}
 
@@ -248,28 +285,31 @@ func TestMerge_OPSecrets(t *testing.T) {
 	if base.OPSecrets == nil {
 		t.Fatal("OPSecrets is nil after merge")
 	}
-	if base.OPSecrets.Password != "op://Work/odoo/api-key" {
-		t.Errorf("OPSecrets.Password = %q, want %q", base.OPSecrets.Password, "op://Work/odoo/api-key")
+	if base.OPSecrets.APIKey != "op://Work/odoo/api-key" {
+		t.Errorf("OPSecrets.APIKey = %q, want %q", base.OPSecrets.APIKey, "op://Work/odoo/api-key")
+	}
+	if base.OPSecrets.Password != "op://Work/odoo/password" {
+		t.Errorf("OPSecrets.Password = %q, want %q", base.OPSecrets.Password, "op://Work/odoo/password")
 	}
 }
 
 func TestMerge_OPSecrets_OverlayReplacesBase(t *testing.T) {
 	base := &Config{
 		OPSecrets: &OPSecrets{
-			Password: "op://Old/odoo/key",
-			URL:      "op://Old/odoo/url",
+			APIKey: "op://Old/odoo/key",
+			URL:    "op://Old/odoo/url",
 		},
 	}
 	overlay := &Config{
 		OPSecrets: &OPSecrets{
-			Password: "op://New/odoo/key",
+			APIKey: "op://New/odoo/key",
 		},
 	}
 
 	base.Merge(overlay)
 
-	if base.OPSecrets.Password != "op://New/odoo/key" {
-		t.Errorf("Password = %q, want overlay value", base.OPSecrets.Password)
+	if base.OPSecrets.APIKey != "op://New/odoo/key" {
+		t.Errorf("APIKey = %q, want overlay value", base.OPSecrets.APIKey)
 	}
 	if base.OPSecrets.URL != "op://Old/odoo/url" {
 		t.Errorf("URL = %q, want base value preserved", base.OPSecrets.URL)
@@ -279,20 +319,20 @@ func TestMerge_OPSecrets_OverlayReplacesBase(t *testing.T) {
 func TestMerge_OPSecrets_NilOverlay(t *testing.T) {
 	base := &Config{
 		OPSecrets: &OPSecrets{
-			Password: "op://Work/odoo/key",
+			APIKey: "op://Work/odoo/key",
 		},
 	}
 	overlay := &Config{}
 
 	base.Merge(overlay)
 
-	if base.OPSecrets == nil || base.OPSecrets.Password != "op://Work/odoo/key" {
+	if base.OPSecrets == nil || base.OPSecrets.APIKey != "op://Work/odoo/key" {
 		t.Error("base OPSecrets should be preserved when overlay has none")
 	}
 }
 
 func TestParseKeyValues(t *testing.T) {
-	input := "url=https://odoo.example.com\ndatabase=mydb\npassword=secret\n"
+	input := "url=https://odoo.example.com\ndatabase=mydb\napi-key=secret\n"
 	got := parseKeyValues(input)
 
 	if got["url"] != "https://odoo.example.com" {
@@ -301,8 +341,8 @@ func TestParseKeyValues(t *testing.T) {
 	if got["database"] != "mydb" {
 		t.Errorf("database = %q", got["database"])
 	}
-	if got["password"] != "secret" {
-		t.Errorf("password = %q", got["password"])
+	if got["api-key"] != "secret" {
+		t.Errorf("api-key = %q", got["api-key"])
 	}
 }
 

--- a/internal/odoo/attendance.go
+++ b/internal/odoo/attendance.go
@@ -35,101 +35,63 @@ func (x *XMLRPCClient) findEmployeeID() (int64, error) {
 	}
 }
 
-// findOpenAttendance searches for an open attendance record (check_out = False)
-// for the given employee. Returns nil if none found.
-func (x *XMLRPCClient) findOpenAttendance(employeeID int64) (map[string]interface{}, error) {
-	criteria := goOdoo.NewCriteria().
-		Add("employee_id", "=", employeeID).
-		Add("check_out", "=", false)
-	opts := goOdoo.NewOptions().
-		FetchFields("id", "employee_id", "check_in", "check_out", "worked_hours").
-		Limit(1)
-
-	records, err := x.searchReadRaw("hr.attendance", criteria, opts)
-	if IsNotFound(err) {
-		return nil, nil
-	}
+// attendanceToggle calls the Odoo systray attendance toggle via JSON-RPC.
+// This controller endpoint internally uses sudo() to bypass hr.attendance
+// ACLs, so it works for non-admin users. Requires an authenticated web
+// session (WebPassword), since Odoo rejects API keys for session auth.
+func (x *XMLRPCClient) attendanceToggle() error {
+	session, err := x.jsonSession()
 	if err != nil {
-		return nil, fmt.Errorf("searching open attendance: %w", err)
+		return err
 	}
-	if len(records) == 0 {
-		return nil, nil
+	_, err = session.call("/hr_attendance/systray_check_in_out", map[string]interface{}{})
+	if err != nil {
+		return fmt.Errorf("toggling attendance: %w", err)
 	}
-	return records[0], nil
+	return nil
 }
 
-// ClockIn creates an attendance record with check_in = now.
-// Returns an error if already clocked in.
+// ClockIn toggles attendance state to clocked-in via the Odoo web controller.
+// Returns the new attendance record ID. Returns an error if already clocked in.
 func (x *XMLRPCClient) ClockIn() (int64, error) {
-	empID, err := x.findEmployeeID()
+	status, err := x.AttendanceStatus()
 	if err != nil {
 		return 0, err
 	}
-
-	open, err := x.findOpenAttendance(empID)
-	if err != nil {
-		return 0, err
-	}
-	if open != nil {
+	if status.ClockedIn {
 		return 0, errors.New("already clocked in")
 	}
 
-	now := time.Now().UTC().Format(odooDatetimeFormat)
-	vals := map[string]interface{}{
-		"employee_id": empID,
-		"check_in":    now,
+	if err := x.attendanceToggle(); err != nil {
+		return 0, err
 	}
 
-	resp, err := x.client.ExecuteKw("create", "hr.attendance",
-		[]interface{}{vals}, goOdoo.NewOptions())
+	// Re-read to get the new record ID.
+	updated, err := x.AttendanceStatus()
 	if err != nil {
-		return 0, fmt.Errorf("creating attendance record: %w", err)
+		return 0, fmt.Errorf("reading status after clock in: %w", err)
 	}
-
-	switch id := resp.(type) {
-	case int64:
-		return id, nil
-	case float64:
-		return int64(id), nil
-	default:
-		return 0, fmt.Errorf("unexpected create response type %T", resp)
-	}
+	return updated.CurrentID, nil
 }
 
-// ClockOut writes check_out = now on the open attendance record.
+// ClockOut toggles attendance state to clocked-out via the Odoo web controller.
 // Returns the completed record with worked_hours.
 func (x *XMLRPCClient) ClockOut() (*AttendanceRecord, error) {
-	empID, err := x.findEmployeeID()
+	status, err := x.AttendanceStatus()
 	if err != nil {
 		return nil, err
 	}
-
-	open, err := x.findOpenAttendance(empID)
-	if err != nil {
-		return nil, err
-	}
-	if open == nil {
+	if !status.ClockedIn {
 		return nil, errors.New("not clocked in")
 	}
 
-	var recordID int64
-	switch id := open["id"].(type) {
-	case int64:
-		recordID = id
-	case float64:
-		recordID = int64(id)
+	recordID := status.CurrentID
+
+	if err := x.attendanceToggle(); err != nil {
+		return nil, err
 	}
 
-	now := time.Now().UTC().Format(odooDatetimeFormat)
-	_, err = x.client.ExecuteKw("write", "hr.attendance",
-		[]interface{}{[]int64{recordID}, map[string]interface{}{
-			"check_out": now,
-		}}, goOdoo.NewOptions())
-	if err != nil {
-		return nil, fmt.Errorf("writing check_out: %w", err)
-	}
-
-	// Re-read the record to get computed worked_hours.
+	// Re-read the closed record to get computed worked_hours.
 	criteria := goOdoo.NewCriteria().Add("id", "=", recordID)
 	opts := goOdoo.NewOptions().
 		FetchFields("id", "employee_id", "check_in", "check_out", "worked_hours")

--- a/internal/odoo/jsonrpc.go
+++ b/internal/odoo/jsonrpc.go
@@ -1,0 +1,237 @@
+package odoo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+)
+
+// jsonRPCSession manages a JSON-RPC session with Odoo.
+// It handles authentication via /web/session/authenticate and
+// maintains session cookies for subsequent requests.
+// This is needed for controller endpoints (like attendance toggle)
+// that require an authenticated web session.
+type jsonRPCSession struct {
+	baseURL       string
+	database      string
+	login         string
+	password      string
+	totpSecret    string
+	httpClient    *http.Client
+	authenticated bool
+	reqID         atomic.Int64
+}
+
+// newJSONRPCSession creates a new JSON-RPC session (not yet authenticated).
+func newJSONRPCSession(baseURL, database, login, password, totpSecret string) *jsonRPCSession {
+	jar, _ := cookiejar.New(nil)
+	return &jsonRPCSession{
+		baseURL:    baseURL,
+		database:   database,
+		login:      login,
+		password:   password,
+		totpSecret: totpSecret,
+		httpClient: &http.Client{
+			Jar: jar,
+		},
+	}
+}
+
+// authenticate performs JSON-RPC session authentication against Odoo.
+// When 2FA (TOTP) is enabled, the initial authenticate returns uid=false
+// and sets a pre_uid in the session. We then complete the TOTP challenge
+// by POSTing the generated code to /web/login/totp.
+func (s *jsonRPCSession) authenticate() error {
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      s.reqID.Add(1),
+		"method":  "call",
+		"params": map[string]interface{}{
+			"db":       s.database,
+			"login":    s.login,
+			"password": s.password,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshalling auth request: %w", err)
+	}
+
+	resp, err := s.httpClient.Post(s.baseURL+"/web/session/authenticate", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("authenticating: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result struct {
+		Error *struct {
+			Message string                 `json:"message"`
+			Data    map[string]interface{} `json:"data"`
+		} `json:"error"`
+		Result map[string]interface{} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding auth response: %w", err)
+	}
+	if result.Error != nil {
+		msg := result.Error.Message
+		if data, ok := result.Error.Data["message"].(string); ok {
+			msg = data
+		}
+		return fmt.Errorf("authentication failed: %s", msg)
+	}
+
+	// Odoo returns uid: false when 2FA is required (pre_uid set in session).
+	if uid, ok := result.Result["uid"]; ok {
+		if uid == false || uid == nil {
+			if s.totpSecret != "" {
+				return s.completeTOTP()
+			}
+			return fmt.Errorf("authentication failed: 2FA is enabled but no TOTP secret configured (set totp_secret in [op_secrets] or ODOO_TOTP_SECRET env var)")
+		}
+	}
+
+	s.authenticated = true
+	return nil
+}
+
+// completeTOTP finishes the 2FA flow by generating a TOTP code and
+// submitting it to /web/login/totp. The session cookie from authenticate()
+// carries the pre_uid that Odoo uses to identify the pending login.
+func (s *jsonRPCSession) completeTOTP() error {
+	secret := parseTOTPSecret(s.totpSecret)
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		return fmt.Errorf("generating TOTP code: %w", err)
+	}
+
+	// GET /web/login/totp to obtain the CSRF token from the form.
+	csrfToken, err := s.fetchCSRFToken("/web/login/totp")
+	if err != nil {
+		return fmt.Errorf("fetching CSRF token: %w", err)
+	}
+
+	// POST the TOTP code as form data. Use a non-redirecting client
+	// so we can distinguish success (302/303 redirect) from failure (200).
+	noRedirect := &http.Client{
+		Jar: s.httpClient.Jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	form := url.Values{
+		"csrf_token": {csrfToken},
+		"totp_token": {code},
+	}
+	totpResp, err := noRedirect.PostForm(s.baseURL+"/web/login/totp", form)
+	if err != nil {
+		return fmt.Errorf("submitting TOTP code: %w", err)
+	}
+	defer func() { _ = totpResp.Body.Close() }()
+
+	// 303 redirect means session was finalized (success).
+	// 200 means the form was re-rendered (wrong code).
+	if totpResp.StatusCode == http.StatusSeeOther || totpResp.StatusCode == http.StatusFound {
+		s.authenticated = true
+		return nil
+	}
+
+	return fmt.Errorf("TOTP verification failed (status %d): check that totp_secret is correct", totpResp.StatusCode)
+}
+
+// csrfTokenRe matches the CSRF token hidden input in Odoo HTML forms.
+var csrfTokenRe = regexp.MustCompile(`name="csrf_token"\s+value="([^"]+)"`)
+
+// fetchCSRFToken GETs a page and extracts the csrf_token from the HTML form.
+func (s *jsonRPCSession) fetchCSRFToken(path string) (string, error) {
+	resp, err := s.httpClient.Get(s.baseURL + path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	matches := csrfTokenRe.FindSubmatch(body)
+	if matches == nil {
+		return "", fmt.Errorf("CSRF token not found in %s response", path)
+	}
+	return string(matches[1]), nil
+}
+
+// parseTOTPSecret extracts the base32 secret from either a raw secret
+// string or an otpauth:// URL.
+func parseTOTPSecret(s string) string {
+	if strings.HasPrefix(s, "otpauth://") {
+		u, err := url.Parse(s)
+		if err == nil {
+			if secret := u.Query().Get("secret"); secret != "" {
+				return secret
+			}
+		}
+	}
+	return s
+}
+
+// call makes a JSON-RPC call to the given path, auto-authenticating if needed.
+func (s *jsonRPCSession) call(path string, params map[string]interface{}) (map[string]interface{}, error) {
+	if !s.authenticated {
+		if err := s.authenticate(); err != nil {
+			return nil, err
+		}
+	}
+
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      s.reqID.Add(1),
+		"method":  "call",
+		"params":  params,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling request: %w", err)
+	}
+
+	resp, err := s.httpClient.Post(s.baseURL+path, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result struct {
+		Error *struct {
+			Message string                 `json:"message"`
+			Data    map[string]interface{} `json:"data"`
+		} `json:"error"`
+		Result map[string]interface{} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response from %s: %w", path, err)
+	}
+	if result.Error != nil {
+		msg := result.Error.Message
+		if data, ok := result.Error.Data["message"].(string); ok {
+			msg = data
+		}
+		return nil, fmt.Errorf("JSON-RPC error from %s: %s", path, msg)
+	}
+
+	return result.Result, nil
+}

--- a/internal/odoo/jsonrpc_test.go
+++ b/internal/odoo/jsonrpc_test.go
@@ -1,0 +1,299 @@
+package odoo
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestJSONRPCSession_Authenticate(t *testing.T) {
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/web/session/authenticate" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "abc123"})
+		resp := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result": map[string]interface{}{
+				"uid": float64(42),
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "secret123", "")
+	err := s.authenticate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !s.authenticated {
+		t.Error("expected authenticated = true")
+	}
+
+	// Verify request body structure.
+	params, _ := gotBody["params"].(map[string]interface{})
+	if params["db"] != "testdb" {
+		t.Errorf("db = %v, want testdb", params["db"])
+	}
+	if params["login"] != "user@test.com" {
+		t.Errorf("login = %v, want user@test.com", params["login"])
+	}
+	if params["password"] != "secret123" {
+		t.Errorf("password = %v, want secret123", params["password"])
+	}
+}
+
+func TestJSONRPCSession_AuthenticateError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"error": map[string]interface{}{
+				"code":    200,
+				"message": "Odoo Server Error",
+				"data": map[string]interface{}{
+					"message": "Access Denied",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	s := newJSONRPCSession(srv.URL, "testdb", "bad@test.com", "wrong", "")
+	err := s.authenticate()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestJSONRPCSession_AuthenticateUIDFalse_NoTOTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result": map[string]interface{}{
+				"uid": false,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "pass", "")
+	err := s.authenticate()
+	if err == nil {
+		t.Fatal("expected error for uid=false without TOTP secret, got nil")
+	}
+	if got := err.Error(); got != "authentication failed: 2FA is enabled but no TOTP secret configured (set totp_secret in [op_secrets] or ODOO_TOTP_SECRET env var)" {
+		t.Errorf("unexpected error message: %s", got)
+	}
+}
+
+func TestJSONRPCSession_AuthenticateWithTOTP(t *testing.T) {
+	var totpPath string
+	var totpFormValues map[string]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/web/session/authenticate":
+			// Return uid=false to trigger 2FA flow.
+			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "pre-auth-session"})
+			resp := map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result": map[string]interface{}{
+					"uid": false,
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "/web/login/totp":
+			if r.Method == http.MethodGet {
+				// Return an HTML page with a CSRF token.
+				w.Header().Set("Content-Type", "text/html")
+				_, _ = w.Write([]byte(`<form><input type="hidden" name="csrf_token" value="test-csrf-42"/></form>`))
+				return
+			}
+			// POST: verify TOTP submission.
+			totpPath = r.URL.Path
+			_ = r.ParseForm()
+			totpFormValues = map[string]string{
+				"csrf_token": r.FormValue("csrf_token"),
+				"totp_token": r.FormValue("totp_token"),
+			}
+			// Simulate success: redirect to /web.
+			w.Header().Set("Location", "/web")
+			w.WriteHeader(http.StatusSeeOther)
+
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	// Use a known TOTP secret and verify that a code was submitted.
+	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "pass", "JBSWY3DPEHPK3PXP")
+	err := s.authenticate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !s.authenticated {
+		t.Error("expected authenticated = true after TOTP")
+	}
+	if totpPath != "/web/login/totp" {
+		t.Errorf("TOTP path = %q, want /web/login/totp", totpPath)
+	}
+	if totpFormValues["csrf_token"] != "test-csrf-42" {
+		t.Errorf("csrf_token = %q, want test-csrf-42", totpFormValues["csrf_token"])
+	}
+	if totpFormValues["totp_token"] == "" {
+		t.Error("totp_token was empty, expected a generated code")
+	}
+}
+
+func TestJSONRPCSession_TOTPVerificationFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/web/session/authenticate":
+			w.Header().Set("Content-Type", "application/json")
+			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "pre-auth"})
+			resp := map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result": map[string]interface{}{
+					"uid": false,
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "/web/login/totp":
+			if r.Method == http.MethodGet {
+				w.Header().Set("Content-Type", "text/html")
+				_, _ = w.Write([]byte(`<form><input type="hidden" name="csrf_token" value="csrf-abc"/></form>`))
+				return
+			}
+			// Return 200 (form re-rendered) = verification failed.
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<form>Error: invalid code</form>`))
+		}
+	}))
+	defer srv.Close()
+
+	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "pass", "JBSWY3DPEHPK3PXP")
+	err := s.authenticate()
+	if err == nil {
+		t.Fatal("expected TOTP verification error, got nil")
+	}
+}
+
+func TestJSONRPCSession_Call(t *testing.T) {
+	authCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/web/session/authenticate" {
+			authCalled = true
+			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "abc123"})
+			resp := map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  map[string]interface{}{"uid": float64(42)},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if r.URL.Path != "/hr_attendance/systray_check_in_out" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		resp := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      2,
+			"result":  map[string]interface{}{"attendance_state": "checked_in"},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "secret123", "")
+	result, err := s.call("/hr_attendance/systray_check_in_out", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !authCalled {
+		t.Error("expected auto-authentication")
+	}
+	if result["attendance_state"] != "checked_in" {
+		t.Errorf("result attendance_state = %v, want checked_in", result["attendance_state"])
+	}
+}
+
+func TestJSONRPCSession_CallErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/web/session/authenticate" {
+			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "abc123"})
+			resp := map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  map[string]interface{}{"uid": float64(42)},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		resp := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      2,
+			"error": map[string]interface{}{
+				"code":    200,
+				"message": "Odoo Server Error",
+				"data": map[string]interface{}{
+					"message": "Something went wrong",
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "secret123", "")
+	_, err := s.call("/hr_attendance/systray_check_in_out", map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestParseTOTPSecret_RawSecret(t *testing.T) {
+	got := parseTOTPSecret("JBSWY3DPEHPK3PXP")
+	if got != "JBSWY3DPEHPK3PXP" {
+		t.Errorf("got %q, want JBSWY3DPEHPK3PXP", got)
+	}
+}
+
+func TestParseTOTPSecret_OTPAuthURL(t *testing.T) {
+	url := "otpauth://totp/example:user@example.com?secret=XYNHNRPRJMRNG6UP&issuer=example&algorithm=SHA1&digits=6&period=30"
+	got := parseTOTPSecret(url)
+	if got != "XYNHNRPRJMRNG6UP" {
+		t.Errorf("got %q, want XYNHNRPRJMRNG6UP", got)
+	}
+}

--- a/internal/odoo/xmlrpc.go
+++ b/internal/odoo/xmlrpc.go
@@ -9,15 +9,24 @@ import (
 )
 
 // XMLRPCClient implements Client using the Odoo XML-RPC API.
+// For operations that require an authenticated web session (e.g. attendance
+// toggle), it lazily initializes a JSON-RPC session using WebPassword.
 type XMLRPCClient struct {
-	client *goOdoo.Client
-	login  string
-	models map[string]config.ModelConfig
+	client      *goOdoo.Client
+	login       string
+	models      map[string]config.ModelConfig
+	url         string
+	database    string
+	webPassword string
+	totpSecret  string
+	jsonRPC     *jsonRPCSession
 }
 
-// NewXMLRPCClient creates a new Odoo client and authenticates.
-// The models parameter provides per-model extra field configuration.
-func NewXMLRPCClient(url, database, username, password string, models map[string]config.ModelConfig) (*XMLRPCClient, error) {
+// NewXMLRPCClient creates a new Odoo client and authenticates via XML-RPC.
+// The webPassword is the user's Odoo login password (not the API key) and
+// is used for JSON-RPC session auth when calling web controllers.
+// Pass empty string if not available (clock in/out will be unavailable).
+func NewXMLRPCClient(url, database, username, password, webPassword, totpSecret string, models map[string]config.ModelConfig) (*XMLRPCClient, error) {
 	c, err := goOdoo.NewClient(&goOdoo.ClientConfig{
 		Admin:    username,
 		Password: password,
@@ -27,12 +36,34 @@ func NewXMLRPCClient(url, database, username, password string, models map[string
 	if err != nil {
 		return nil, fmt.Errorf("connecting to odoo: %w", err)
 	}
-	return &XMLRPCClient{client: c, login: username, models: models}, nil
+	return &XMLRPCClient{
+		client:      c,
+		login:       username,
+		models:      models,
+		url:         url,
+		database:    database,
+		webPassword: webPassword,
+		totpSecret:  totpSecret,
+	}, nil
 }
 
 // Close closes the underlying XML-RPC connections.
 func (x *XMLRPCClient) Close() {
 	x.client.Close()
+}
+
+// jsonSession returns a lazily-initialized JSON-RPC session.
+// Uses WebPassword (the actual Odoo login password) for session auth,
+// since API keys are rejected by Odoo's web session authenticate
+// (it passes interactive: true which skips API key checking).
+func (x *XMLRPCClient) jsonSession() (*jsonRPCSession, error) {
+	if x.webPassword == "" {
+		return nil, fmt.Errorf("web_password not configured; required for clock in/out (set via [op_secrets] web_password or ODOO_WEB_PASSWORD env var)")
+	}
+	if x.jsonRPC == nil {
+		x.jsonRPC = newJSONRPCSession(x.url, x.database, x.login, x.webPassword, x.totpSecret)
+	}
+	return x.jsonRPC, nil
 }
 
 // searchReadRaw calls ExecuteKw("search_read", ...) and returns raw maps.

--- a/mise.toml
+++ b/mise.toml
@@ -16,6 +16,11 @@ go build -ldflags "-X github.com/seletz/odoo-work-cli/internal/version.Version=$
 description = "Create a new release (interactive semver bump)"
 run = "scripts/release.sh"
 
+[tasks.run]
+description = "Build and run the CLI (pass args after --)"
+depends = ["build"]
+run = "./odoo-work-cli {{arg(i=0, var=true)}}"
+
 [tasks.test]
 description = "Run all tests"
 run = "go test ./..."

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ CLI tool for managing Odoo 17 timesheets and projects from the terminal, as well
 
 - **CLI:** CLI commands for scripting
 - **TUI:** Terminal UI for fast interactive usage
+- **Clock in/out:** Works for non-admin users, including accounts with 2FA (TOTP) enabled
 - **Config bootstrapping:** `config install` creates a default config file
 
 ### TUI Features
@@ -78,8 +79,8 @@ Commands:
 | `entries add --project-id N --hours H --description "…"` | Create a new timesheet entry (hours: `2.5` or `2:30`, date defaults to today, task-id optional)                     |
 | `entries update ID [--hours H] [--description "…"] …`    | Partially update a timesheet entry (hours: `2.5` or `2:30`, only set flags are sent)                                |
 | `entries delete ID`                                      | Delete a timesheet entry by ID                                                                                      |
-| `clock in`                                               | Clock in (start attendance period)                                                                                  |
-| `clock out`                                              | Clock out (end attendance period, shows duration)                                                                   |
+| `clock in`                                               | Clock in (start attendance period). Works for non-admin users via JSON-RPC; supports 2FA (TOTP).                    |
+| `clock out`                                              | Clock out (end attendance period, shows duration). Works for non-admin users via JSON-RPC; supports 2FA (TOTP).     |
 | `clock status`                                           | Show current attendance state and today's periods                                                                   |
 | `tui`                                                    | Weekly timesheet TUI with detail view (auto-reloads from Odoo), inline editing/adding, and live clock-in/out status |
 | `fields <model>`                                         | Inspect field metadata for any Odoo model                                                                           |
@@ -123,7 +124,7 @@ Configuration is loaded in layers, with later layers overriding earlier ones:
 1. **Global config**: `$XDG_CONFIG_HOME/odoo-work-cli/config.toml` (defaults to `~/.config/odoo-work-cli/config.toml`)
 2. **Directory walk**: `.odoo-work-cli.toml` files from filesystem root down to cwd (root-most first, like `.editorconfig`)
 3. **`[op_secrets]`**: resolved via 1Password CLI at runtime (see below)
-4. **Environment variables**: `ODOO_URL`, `ODOO_DATABASE`, `ODOO_USERNAME`, `ODOO_PASSWORD` (highest priority)
+4. **Environment variables**: `ODOO_URL`, `ODOO_DATABASE`, `ODOO_USERNAME`, `ODOO_PASSWORD`, `ODOO_WEB_PASSWORD`, `ODOO_TOTP_SECRET` (highest priority)
 5. **`--config` flag**: Skip discovery entirely, load only the specified file + op_secrets + env vars
 
 ### Secrets (via 1Password)
@@ -134,18 +135,27 @@ reference automatically. No manual injection step needed.
 
 ```toml
 [op_secrets]
-url      = "op://Employee/odoo/url"
-database = "op://Employee/odoo/database"
-username = "op://Employee/odoo/username"
-password = "op://Employee/odoo/api-key"
+url         = "op://Employee/odoo/url"
+database    = "op://Employee/odoo/database"
+username    = "op://Employee/odoo/username"
+api-key     = "op://Employee/odoo/api-key"        # Odoo API key (for XML-RPC reads)
+password    = "op://Employee/odoo/password"        # Odoo login password (for clock in/out)
+totp_secret = "op://Employee/odoo/totp_secret"     # TOTP secret (for 2FA, if enabled)
 ```
+
+The CLI uses **two separate credentials**:
+
+- **`api-key`** — Odoo API key used for XML-RPC operations (timesheets, projects, tasks). Created in Odoo Settings > Users > API Keys.
+- **`password`** — Odoo login password used for JSON-RPC web session auth (clock in/out). Required because Odoo's web session authenticate rejects API keys.
+- **`totp_secret`** — Base32 TOTP secret for 2FA. Only needed if your Odoo account has two-factor authentication enabled. The value can be a raw base32 secret or a full `otpauth://` URL.
 
 Values without the `op://` prefix are used as-is (useful for non-secret fields
 like database name). If `op` is not installed or the `[op_secrets]` section is
-absent, the CLI falls back to environment variables.
+absent, the CLI falls back to environment variables (`ODOO_PASSWORD`,
+`ODOO_WEB_PASSWORD`, `ODOO_TOTP_SECRET`).
 
 Plain-text passwords in config files are still rejected — passwords must come
-from `[op_secrets]` or the `ODOO_PASSWORD` env var.
+from `[op_secrets]` or environment variables.
 
 ### Config file example
 
@@ -162,10 +172,12 @@ bundesland = "Baden-Württemberg"
 # Use [op_secrets] below for 1Password, or set ODOO_PASSWORD env var.
 
 # [op_secrets]
-# url      = "op://vault/item/url"
-# database = "op://vault/item/database"
-# username = "op://vault/item/username"
-# password = "op://vault/item/api-key"
+# url         = "op://vault/item/url"
+# database    = "op://vault/item/database"
+# username    = "op://vault/item/username"
+# api-key     = "op://vault/item/api-key"        # Odoo API key (for XML-RPC)
+# password    = "op://vault/item/password"        # Odoo login password (for clock in/out)
+# totp_secret = "op://vault/item/totp_secret"     # TOTP secret (if 2FA enabled)
 
 [hours]
 daily_low = 6.0    # below this: yellow


### PR DESCRIPTION
## Summary

- Switch clock in/out from direct XML-RPC `create`/`write` on `hr.attendance` (admin-only) to JSON-RPC session + `/hr_attendance/systray_check_in_out` controller endpoint, which uses `sudo()` internally
- Add TOTP 2FA support: when Odoo's `/web/session/authenticate` returns `uid=false` (2FA pending), auto-generate a TOTP code from the configured secret and complete verification via `/web/login/totp`
- Add dual credential support in `[op_secrets]`: `api-key` for XML-RPC reads, `password` for web session auth, `totp_secret` for 2FA
- Update README: features, usage, secrets documentation

Closes #29

## New files

- `internal/odoo/jsonrpc.go` — JSON-RPC session layer with cookie jar, TOTP flow, CSRF handling
- `internal/odoo/jsonrpc_test.go` — tests with httptest (auth, 2FA, TOTP verification, error cases)

## Modified files

- `internal/config/config.go` — `TOTPSecret` field, env var, merge
- `internal/config/op.go` — `TOTPSecret` in OPSecrets, field mapping
- `internal/config/op_test.go` — updated tests for new fields
- `internal/odoo/xmlrpc.go` — pass TOTP secret to JSON-RPC session
- `internal/odoo/attendance.go` — ClockIn/ClockOut use JSON-RPC toggle
- `cmd/odoo-work-cli/main.go` — wire TOTPSecret to client constructor
- `internal/config/default_config.toml` — document new op_secrets fields
- `readme.md` — features, usage, secrets documentation

## Test plan

- [x] `mise run test` — all tests pass
- [x] `mise run lint` — 0 issues
- [x] Manual: `clock status` (XML-RPC read, works for all users)
- [x] Manual: `clock out` with 2FA-enabled account
- [x] Manual: `clock in` with 2FA-enabled account
- [x] Manual: `clock status` shows updated periods after in/out cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)