### PR TITLE
TUI: visual polish with colours, borders, and effects

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -795,6 +795,16 @@ func formatDecimalHours(h float64) string {
 func (m Model) View() tea.View {
 	var s string
 
+	// Compute today's column for the displayed week (-1 if not this week).
+	todayCol := TodayColumn(m.monday.Time, time.Now())
+	nowDate := time.Now()
+	monDate := time.Date(m.monday.Year(), m.monday.Month(), m.monday.Day(), 0, 0, 0, 0, m.monday.Location())
+	nowDateOnly := time.Date(nowDate.Year(), nowDate.Month(), nowDate.Day(), 0, 0, 0, 0, nowDate.Location())
+	daysSince := int(nowDateOnly.Sub(monDate).Hours() / 24)
+	if daysSince < 0 || daysSince > 6 {
+		todayCol = -1
+	}
+
 	switch m.state {
 	case stateLoading:
 		week := m.monday.Format("2006-01-02")
@@ -804,41 +814,27 @@ func (m Model) View() tea.View {
 		s = fmt.Sprintf("\n  Error: %s\n\n  Press 'r' to retry or 'q' to quit.\n\n", m.err)
 
 	case stateGrid, stateDetail, stateEdit, stateSearch, stateHelp:
-		sunday := m.monday.AddDate(0, 0, 6)
-		loadingIndicator := ""
-		if m.loading {
-			loadingIndicator = " " + m.spinner.View()
-		}
-		_, isoWeek := m.monday.ISOWeek()
-		clockStatus := renderClockStatus(m.attendance)
-		if clockStatus != "" {
-			clockStatus = "  " + clockStatus
-		}
-		title := fmt.Sprintf("  W%02d: %s — %s%s%s\n\n",
-			isoWeek,
-			m.monday.Format("Mon 02 Jan 2006"),
-			sunday.Format("Mon 02 Jan 2006"),
-			loadingIndicator,
-			clockStatus)
-		grid := RenderGrid(m.grid, m.cursor[0], m.cursor[1], m.width-4, m.limits, m.weekHols, m.companyColors)
+		headerBar := RenderHeaderBar(m.monday.Time, m.attendance, m.loading, m.spinner, m.width)
+		grid := RenderGrid(m.grid, m.cursor[0], m.cursor[1], m.width-4, m.limits, m.weekHols, m.companyColors, todayCol)
+		statusBar := RenderStatusBar(m.state, m.grid.WeekTotal, m.limits, m.attendance, m.width)
 
 		helpView := m.help.View(m.keys)
-		s = "\n" + title + grid + "\n  " + helpView + "\n"
+		s = headerBar + "\n\n" + grid + "\n  " + helpView + "\n" + statusBar + "\n"
 
 		if m.state == stateEdit && m.cursor[0] < len(m.grid.Rows) {
 			row := m.grid.Rows[m.cursor[0]]
 			day := m.monday.AddDate(0, 0, m.cursor[1])
 			edit := renderEditForm(row, day, m.editHours, m.editDesc, m.editFocus, m.editErr, m.width, m.editIsNew)
-			s = RenderDetailOverlay(s, edit, m.width, m.height)
+			s = RenderDetailOverlay(s, edit, m.width, m.height, editBoxStyle)
 		} else if m.state == stateDetail && m.cursor[0] < len(m.grid.Rows) {
 			detail := RenderDetail(m.grid.Rows[m.cursor[0]], m.cursor[1], m.monday.Time, m.detailCursor, m.width, m.companyColors)
-			s = RenderDetailOverlay(s, detail, m.width, m.height)
+			s = RenderDetailOverlay(s, detail, m.width, m.height, detailBoxStyle)
 		} else if m.state == stateSearch {
 			search := renderSearchOverlay(m.searchInput, m.searchFiltered, m.searchCursor, m.searchSub, m.searchUseFilter, m.searchErr, m.spinner, m.width, m.height, m.companyColors)
-			s = RenderDetailOverlay(s, search, m.width, m.height)
+			s = RenderDetailOverlay(s, search, m.width, m.height, searchBoxStyle)
 		} else if m.state == stateHelp {
 			helpContent := renderHelpOverlay(m.keys, m.width, m.height)
-			s = RenderDetailOverlay(s, helpContent, m.width, m.height)
+			s = RenderDetailOverlay(s, helpContent, m.width, m.height, helpBoxStyle)
 		}
 	}
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -343,8 +343,8 @@ func TestRenderClockStatus_Nil(t *testing.T) {
 func TestRenderClockStatus_NotClockedIn(t *testing.T) {
 	status := &odoo.AttendanceStatus{ClockedIn: false}
 	result := renderClockStatus(status)
-	if !strings.Contains(result, "Not clocked in") {
-		t.Fatalf("expected 'Not clocked in' in %q", result)
+	if !strings.Contains(result, "Out") {
+		t.Fatalf("expected 'Out' in %q", result)
 	}
 }
 
@@ -352,8 +352,8 @@ func TestRenderClockStatus_ClockedIn(t *testing.T) {
 	checkIn := time.Now().Add(-90 * time.Minute)
 	status := &odoo.AttendanceStatus{ClockedIn: true, CheckIn: &checkIn}
 	result := renderClockStatus(status)
-	if !strings.Contains(result, "Clocked in since") {
-		t.Fatalf("expected 'Clocked in since' in %q", result)
+	if !strings.Contains(result, "In") {
+		t.Fatalf("expected 'In' in %q", result)
 	}
 }
 
@@ -1407,11 +1407,11 @@ func TestRenderSearchOverlay(t *testing.T) {
 	if !strings.Contains(result, "Tasks:") {
 		t.Fatal("expected 'Tasks:' section")
 	}
-	if !strings.Contains(result, "[P] Alpha") {
-		t.Fatal("expected '[P] Alpha' in output")
+	if !strings.Contains(result, "Alpha") {
+		t.Fatal("expected 'Alpha' in output")
 	}
-	if !strings.Contains(result, "[T] Task X") {
-		t.Fatal("expected '[T] Task X' in output")
+	if !strings.Contains(result, "Task X") {
+		t.Fatal("expected 'Task X' in output")
 	}
 }
 

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -15,10 +15,122 @@ import (
 
 var dayNames = [7]string{"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"}
 
+// Box-drawing characters for grid borders.
+const (
+	boxH  = "─"
+	boxV  = "│"
+	boxTL = "┬"
+	boxBL = "┴"
+	boxX  = "┼"
+	boxLL = "├"
+	boxLR = "┤"
+)
+
+// RenderHeaderBar renders a styled top header bar with app name, week number,
+// date range, clock status, and loading indicator.
+func RenderHeaderBar(monday time.Time, attendance *odoo.AttendanceStatus, loading bool, spin spinner.Model, width int) string {
+	sunday := monday.AddDate(0, 0, 6)
+	_, isoWeek := monday.ISOWeek()
+
+	weekNum := weekNumberStyle.Render(fmt.Sprintf("W%02d", isoWeek))
+	dateRange := fmt.Sprintf("%s — %s",
+		monday.Format("Mon 02 Jan 2006"),
+		sunday.Format("Mon 02 Jan 2006"))
+
+	left := fmt.Sprintf(" %s  %s", weekNum, dateRange)
+
+	loadingIndicator := ""
+	if loading {
+		loadingIndicator = " " + spin.View()
+	}
+
+	clockStatus := renderClockStatus(attendance)
+	right := clockStatus + loadingIndicator + " "
+
+	// Manually pad to full width so we don't rely on lipgloss Width wrapping
+	// (which can break with nested ANSI sequences).
+	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+	bar := left + strings.Repeat(" ", gap) + right
+
+	return headerBarStyle.UnsetPadding().Render(bar)
+}
+
+// RenderStatusBar renders a styled bottom status bar showing current state context.
+func RenderStatusBar(state uiState, weekTotal float64, limits config.HoursLimits, attendance *odoo.AttendanceStatus, width int) string {
+	stateLabel := ""
+	switch state {
+	case stateGrid:
+		stateLabel = "GRID"
+	case stateDetail:
+		stateLabel = "DETAIL"
+	case stateEdit:
+		stateLabel = "EDIT"
+	case stateSearch:
+		stateLabel = "SEARCH"
+	case stateHelp:
+		stateLabel = "HELP"
+	}
+
+	left := " " + stateLabel
+
+	totalStr := FormatHours(weekTotal)
+	if totalStr == "" {
+		totalStr = "0:00"
+	}
+	totalStyled := weekTotalStyle(weekTotal, limits).Render(totalStr)
+	right := "Week: " + totalStyled + " "
+
+	// Manually pad to full width so we don't rely on lipgloss Width wrapping
+	// (which can break with nested ANSI sequences).
+	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+	bar := left + strings.Repeat(" ", gap) + right
+
+	return statusBarStyle.UnsetPadding().Render(bar)
+}
+
+// buildGridSeparator builds a box-drawing separator line with connectors.
+func buildGridSeparator(labelWidth, colWidth int, top bool) string {
+	var b strings.Builder
+	b.WriteString(strings.Repeat(boxH, labelWidth+2))
+	for i := 0; i < 8; i++ {
+		connector := boxX
+		if top {
+			connector = boxTL
+		}
+		if i == 0 {
+			connector = boxX
+			if top {
+				connector = boxTL
+			}
+		}
+		b.WriteString(connector)
+		b.WriteString(strings.Repeat(boxH, colWidth-1))
+	}
+	return gridSepStyle.Render(b.String())
+}
+
+// buildGridSeparatorBottom builds a bottom separator line.
+func buildGridSeparatorBottom(labelWidth, colWidth int) string {
+	var b strings.Builder
+	b.WriteString(strings.Repeat(boxH, labelWidth+2))
+	for i := 0; i < 8; i++ {
+		b.WriteString(boxBL)
+		b.WriteString(strings.Repeat(boxH, colWidth-1))
+	}
+	return gridSepStyle.Render(b.String())
+}
+
 // RenderGrid renders the weekly grid as a styled string.
 // holidays is a [7]string with holiday names per day (empty = no holiday).
 // companyColors maps company name to lipgloss color string for row label coloring.
-func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.HoursLimits, holidays [7]string, companyColors map[string]string) string {
+// todayCol is the column index (0-6) for today, or -1 if not in this week.
+func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.HoursLimits, holidays [7]string, companyColors map[string]string, todayCol int) string {
 	minColWidth := 7
 	minLabelWidth := 20
 	maxLabelWidth := 40
@@ -41,11 +153,13 @@ func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.Ho
 
 	var b strings.Builder
 
-	// Header row.
+	// Header row with vertical separators.
 	header := fmt.Sprintf("%-*s  ", labelWidth, "Project / Task")
 	for i, name := range dayNames {
-		cell := fmt.Sprintf("%*s", colWidth, name)
+		cell := fmt.Sprintf("%*s", colWidth-1, name)
 		switch {
+		case i == todayCol && !isHoliday(i):
+			cell = todayHeaderStyle.Render(cell)
 		case isHoliday(i):
 			cell = holidayStyle.Render(cell)
 		case i >= 5:
@@ -53,9 +167,9 @@ func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.Ho
 		default:
 			cell = headerStyle.Render(cell)
 		}
-		header += cell
+		header += gridSepStyle.Render(boxV) + cell
 	}
-	header += headerStyle.Render(fmt.Sprintf("%*s", colWidth, "Total"))
+	header += gridSepStyle.Render(boxV) + headerStyle.Render(fmt.Sprintf("%*s", colWidth-1, "Total"))
 	b.WriteString(header)
 	b.WriteString("\n")
 
@@ -71,19 +185,20 @@ func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.Ho
 		hline := fmt.Sprintf("%-*s  ", labelWidth, "")
 		for d := 0; d < 7; d++ {
 			name := holidays[d]
-			if len(name) > colWidth {
-				name = name[:colWidth-1] + "…"
+			if len(name) > colWidth-1 {
+				name = name[:colWidth-2] + "…"
 			}
-			cell := fmt.Sprintf("%*s", colWidth, name)
+			cell := fmt.Sprintf("%*s", colWidth-1, name)
 			cell = holidayStyle.Render(cell)
-			hline += cell
+			hline += gridSepStyle.Render(boxV) + cell
 		}
+		hline += gridSepStyle.Render(boxV)
 		b.WriteString(hline)
 		b.WriteString("\n")
 	}
 
-	// Separator.
-	b.WriteString(strings.Repeat("─", labelWidth+2+8*colWidth))
+	// Top separator with connectors.
+	b.WriteString(buildGridSeparator(labelWidth, colWidth, true))
 	b.WriteString("\n")
 
 	// Data rows.
@@ -101,7 +216,7 @@ func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.Ho
 		var rowTotal float64
 		for d := 0; d < 7; d++ {
 			rowTotal += row.Hours[d]
-			cell := fmt.Sprintf("%*s", colWidth, FormatHours(row.Hours[d]))
+			cell := fmt.Sprintf("%*s", colWidth-1, FormatHours(row.Hours[d]))
 			switch {
 			case ri == cursorRow && d == cursorCol:
 				cell = cursorStyle.Render(cell)
@@ -110,31 +225,36 @@ func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.Ho
 			case d >= 5:
 				cell = weekendStyle.Render(cell)
 			case row.Hours[d] > 0:
-				cell = hoursStyle(grid.DayTotals[d], limits).Render(cell)
+				cell = hoursBgStyle(grid.DayTotals[d], limits).Render(cell)
+			case d == todayCol:
+				cell = todayCellStyle.Render(cell)
 			}
-			line += cell
+			line += gridSepStyle.Render(boxV) + cell
 		}
-		totalCell := fmt.Sprintf("%*s", colWidth, FormatHours(rowTotal))
-		line += totalsStyle.Render(totalCell)
+		totalCell := fmt.Sprintf("%*s", colWidth-1, FormatHours(rowTotal))
+		line += gridSepStyle.Render(boxV) + totalsStyle.Render(totalCell)
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
 
-	// Totals row.
-	b.WriteString(strings.Repeat("─", labelWidth+2+8*colWidth))
+	// Bottom separator.
+	b.WriteString(buildGridSeparatorBottom(labelWidth, colWidth))
 	b.WriteString("\n")
-	totalsLine := fmt.Sprintf("%-*s  ", labelWidth, "Total")
+
+	// Totals row with background emphasis.
+	totalsLabel := totalsRowStyle.Render(fmt.Sprintf("%-*s", labelWidth, "Total"))
+	totalsLine := totalsLabel + "  "
 	for d := 0; d < 7; d++ {
-		cell := fmt.Sprintf("%*s", colWidth, FormatHours(grid.DayTotals[d]))
+		cell := fmt.Sprintf("%*s", colWidth-1, FormatHours(grid.DayTotals[d]))
 		if isHoliday(d) {
 			cell = holidayStyle.Bold(true).Render(cell)
 		} else {
-			cell = totalsStyle.Render(cell)
+			cell = totalsRowStyle.Render(cell)
 		}
-		totalsLine += cell
+		totalsLine += gridSepStyle.Render(boxV) + cell
 	}
-	weekCell := fmt.Sprintf("%*s", colWidth, FormatHours(grid.WeekTotal))
-	totalsLine += weekTotalStyle(grid.WeekTotal, limits).Bold(true).Render(weekCell)
+	weekCell := fmt.Sprintf("%*s", colWidth-1, FormatHours(grid.WeekTotal))
+	totalsLine += gridSepStyle.Render(boxV) + weekTotalBoldStyle.Render(weekTotalStyle(grid.WeekTotal, limits).Bold(true).Render(weekCell))
 	b.WriteString(totalsLine)
 	b.WriteString("\n")
 
@@ -230,8 +350,9 @@ func detailTableStyles() table.Styles {
 }
 
 // RenderDetailOverlay composites a bordered detail box centered on top of bg.
-func RenderDetailOverlay(bg, detail string, bgWidth, bgHeight int) string {
-	box := detailBoxStyle.Render(detail)
+// boxStyle selects which border style to use for the overlay.
+func RenderDetailOverlay(bg, detail string, bgWidth, bgHeight int, boxStyle lipgloss.Style) string {
+	box := boxStyle.Render(detail)
 
 	boxLines := strings.Split(box, "\n")
 	bgLines := strings.Split(bg, "\n")
@@ -278,12 +399,12 @@ func renderClockStatus(attendance *odoo.AttendanceStatus) string {
 		return ""
 	}
 	if !attendance.ClockedIn || attendance.CheckIn == nil {
-		return clockedOutStyle.Render("🔴 Not clocked in")
+		return clockedOutStyle.Render("● Out")
 	}
 	elapsed := time.Since(*attendance.CheckIn)
 	h := int(elapsed.Hours())
 	m := int(elapsed.Minutes()) % 60
-	text := fmt.Sprintf("🟢 Clocked in since %s (%d:%02d)",
+	text := fmt.Sprintf("● In %s (%d:%02d)",
 		attendance.CheckIn.Local().Format("15:04"), h, m)
 	return clockedInStyle.Render(text)
 }
@@ -435,7 +556,14 @@ func renderSearchOverlay(input textinput.Model, items []searchItem, cursor int, 
 				lastKind = item.Kind
 			}
 
-			label := fmt.Sprintf("    [%s] %s", strings.ToUpper(item.Kind[:1]), item.Name)
+			// Colored badge for kind.
+			var badge string
+			if item.Kind == "project" {
+				badge = searchProjectBadge.Render("[P]")
+			} else {
+				badge = searchTaskBadge.Render("[T]")
+			}
+			label := fmt.Sprintf("    %s %s", badge, item.Name)
 			if item.Extra != "" {
 				extra := item.Extra
 				if item.Kind == "project" {

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -14,7 +14,7 @@ func TestRenderGrid_ContainsLabels(t *testing.T) {
 		{Date: "2026-03-03", Project: "Beta", Task: "QA", Hours: 2.5},
 	}
 	g := BuildWeekGrid(entries, monday(2026, 3, 2))
-	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil)
+	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil, -1)
 
 	if !strings.Contains(out, "Acme / Dev") {
 		t.Error("output should contain 'Acme / Dev'")
@@ -32,7 +32,7 @@ func TestRenderGrid_ContainsLabels(t *testing.T) {
 
 func TestRenderGrid_EmptyGrid(t *testing.T) {
 	g := BuildWeekGrid(nil, monday(2026, 3, 2))
-	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil)
+	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil, -1)
 
 	if !strings.Contains(out, "Project / Task") {
 		t.Error("output should contain header")
@@ -108,14 +108,14 @@ func TestRenderDetailOverlay_CentersBox(t *testing.T) {
 	row.Hours[0] = 1.0
 
 	detail := RenderDetail(row, 0, monday(2026, 3, 2), 0, 60, nil)
-	result := RenderDetailOverlay(bg, detail, 60, 20)
+	result := RenderDetailOverlay(bg, detail, 60, 20, detailBoxStyle)
 
-	// The overlay should contain the box border characters.
-	if !strings.Contains(result, "╭") {
-		t.Error("overlay should contain rounded border top-left")
+	// The overlay should contain the double border characters.
+	if !strings.Contains(result, "╔") {
+		t.Error("overlay should contain double border top-left")
 	}
-	if !strings.Contains(result, "╯") {
-		t.Error("overlay should contain rounded border bottom-right")
+	if !strings.Contains(result, "╝") {
+		t.Error("overlay should contain double border bottom-right")
 	}
 	// Background dots should still be visible outside the box.
 	if !strings.Contains(result, "...") {
@@ -130,7 +130,7 @@ func TestRenderGrid_CorrectLineCount(t *testing.T) {
 		{Date: "2026-03-02", Project: "C", Task: "T3", Hours: 3.0},
 	}
 	g := BuildWeekGrid(entries, monday(2026, 3, 2))
-	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil)
+	out := RenderGrid(g, 0, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil, -1)
 
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 	// header + sep + 3 data rows + sep + totals = 7

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -5,33 +5,112 @@ import (
 	"github.com/seletz/odoo-work-cli/internal/config"
 )
 
+// Color palette — cohesive set of named colors used throughout the TUI.
+var (
+	colorBlue    = lipgloss.Color("#5f87ff")
+	colorCyan    = lipgloss.Color("#5fd7ff")
+	colorGreen   = lipgloss.Color("#5fd75f")
+	colorYellow  = lipgloss.Color("#d7d75f")
+	colorRed     = lipgloss.Color("#ff5f5f")
+	colorMagenta = lipgloss.Color("#d75fd7")
+	colorGold    = lipgloss.Color("#d7af5f")
+	colorFg      = lipgloss.Color("#d0d0d0")
+	colorBarBg   = lipgloss.Color("#262626")
+)
+
 var (
 	headerStyle  = lipgloss.NewStyle().Bold(true)
 	weekendStyle = lipgloss.NewStyle().Faint(true)
 	totalsStyle  = lipgloss.NewStyle().Bold(true)
-	cursorStyle  = lipgloss.NewStyle().Reverse(true)
 
-	holidayStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5")) // magenta
-	hoursLow     = lipgloss.NewStyle().Foreground(lipgloss.Color("3")) // yellow
-	hoursNormal  = lipgloss.NewStyle().Foreground(lipgloss.Color("2")) // green
-	hoursHigh    = lipgloss.NewStyle().Foreground(lipgloss.Color("1")) // red
+	// Cursor: bold white on blue background instead of plain Reverse.
+	cursorStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#ffffff")).
+			Background(colorBlue)
 
+	holidayStyle = lipgloss.NewStyle().Foreground(colorMagenta)
+	hoursLow     = lipgloss.NewStyle().Foreground(colorYellow)
+	hoursNormal  = lipgloss.NewStyle().Foreground(colorGreen)
+	hoursHigh    = lipgloss.NewStyle().Foreground(colorRed)
+
+	// Hour cell background tints for data cells.
+	hoursBgLow    = lipgloss.NewStyle().Foreground(colorYellow).Background(lipgloss.Color("#2a2a1a"))
+	hoursBgNormal = lipgloss.NewStyle().Foreground(colorGreen).Background(lipgloss.Color("#1a2a1a"))
+	hoursBgHigh   = lipgloss.NewStyle().Foreground(colorRed).Background(lipgloss.Color("#2a1a1a"))
+
+	// Week number style — bold cyan.
+	weekNumberStyle = lipgloss.NewStyle().Bold(true).Foreground(colorCyan)
+
+	// Header bar: full-width background bar.
+	headerBarStyle = lipgloss.NewStyle().
+			Background(colorBarBg).
+			Foreground(colorFg).
+			Bold(true).
+			Padding(0, 1)
+
+	// Today column header: underlined.
+	todayHeaderStyle = lipgloss.NewStyle().Bold(true).
+				Foreground(colorCyan).
+				Underline(true)
+
+	// Today column cells: subtle background tint.
+	todayCellStyle = lipgloss.NewStyle().Background(lipgloss.Color("#1a2a2a"))
+
+	// Totals row: bold with a subtle background.
+	totalsRowStyle = lipgloss.NewStyle().Bold(true).Background(lipgloss.Color("#262626"))
+
+	// Week total in totals row: extra emphasis.
+	weekTotalBoldStyle = lipgloss.NewStyle().Bold(true).Background(lipgloss.Color("#303030"))
+
+	// Grid separator: faint box-drawing lines.
+	gridSepStyle = lipgloss.NewStyle().Faint(true)
+
+	// Detail overlay: double border with blue foreground.
 	detailHeaderStyle = lipgloss.NewStyle().Bold(true)
 	detailBoxStyle    = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("4")). // blue
+				Border(lipgloss.DoubleBorder()).
+				BorderForeground(colorBlue).
 				Padding(1, 2)
 
-	clockedInStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true) // green
-	clockedOutStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))            // red
+	// Edit overlay: rounded border with green foreground.
+	editBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorGreen).
+			Padding(1, 2)
+
+	// Search overlay: thick border with magenta foreground.
+	searchBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.ThickBorder()).
+			BorderForeground(colorMagenta).
+			Padding(1, 2)
+
+	// Help overlay: rounded border with gold foreground.
+	helpBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorGold).
+			Padding(1, 2)
+
+	clockedInStyle  = lipgloss.NewStyle().Foreground(colorGreen).Bold(true)
+	clockedOutStyle = lipgloss.NewStyle().Foreground(colorRed)
 
 	detailHintStyle      = lipgloss.NewStyle().Faint(true)
 	editLabelStyle       = lipgloss.NewStyle().Faint(true)
 	editActiveLabelStyle = lipgloss.NewStyle().Bold(true)
-	editErrorStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("1")) // red
+	editErrorStyle       = lipgloss.NewStyle().Foreground(colorRed)
 
-	searchFilterWarning = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true) // yellow
+	searchFilterWarning = lipgloss.NewStyle().Foreground(colorYellow).Bold(true)
 	searchSectionStyle  = lipgloss.NewStyle().Bold(true).Faint(true)
+
+	// Search result badges.
+	searchProjectBadge = lipgloss.NewStyle().Foreground(colorBlue).Bold(true)
+	searchTaskBadge    = lipgloss.NewStyle().Foreground(colorGreen).Bold(true)
+
+	// Status bar at bottom.
+	statusBarStyle = lipgloss.NewStyle().
+			Background(colorBarBg).
+			Foreground(colorFg).
+			Padding(0, 1)
 )
 
 // companyLabelStyle returns a style with the given lipgloss color as foreground.
@@ -39,15 +118,15 @@ func companyLabelStyle(color string) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(color))
 }
 
-// hoursStyle returns the appropriate style based on daily total hours.
-func hoursStyle(total float64, limits config.HoursLimits) lipgloss.Style {
+// hoursBgStyle returns hour style with a faint background tint.
+func hoursBgStyle(total float64, limits config.HoursLimits) lipgloss.Style {
 	switch {
 	case total > limits.DailyHigh:
-		return hoursHigh
+		return hoursBgHigh
 	case total >= limits.DailyLow:
-		return hoursNormal
+		return hoursBgNormal
 	default:
-		return hoursLow
+		return hoursBgLow
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add styled **header bar** (cyan week number, date range, clock status) and **status bar** (view state, week total)
- Replace plain `─` separators with **box-drawing grid** (`│`, `┬`, `┼`, `┴` connectors) with faint styling
- **Today column highlight** — underlined cyan header + subtle background tint on cells
- **Colored cursor** — blue background + bold white replaces plain Reverse
- **Distinct overlay borders** per type: Detail (double/blue), Edit (rounded/green), Search (thick/magenta), Help (rounded/gold)
- **Hour cell background tints** — faint yellow/green/red backgrounds based on daily totals
- **Totals row** with background emphasis and bold week total
- **Colored search badges** — `[P]` in blue, `[T]` in green for project/task results
- Named color palette for consistency across all styles

<img width="981" height="245" alt="image" src="https://github.com/user-attachments/assets/60e2f3b9-a1d0-4190-90cf-7866bd719436" />


## Test plan
- [x] `mise run build` compiles
- [x] `mise run test` — all existing tests pass (updated for new signatures)
- [x] `mise run lint` — zero issues
- [x] Manual: header bar single-line with week number + clock status
- [x] Manual: status bar single-line with view state + week total
- [x] Manual: today column visually distinct
- [x] Manual: box-drawing grid borders render correctly
- [x] Manual: cursor is blue/white, overlays have distinct borders

Closes #4