### PR TITLE
feat: local test setup targets odoo-erp dev environment (#48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 # OS
 .DS_Store
 Thumbs.db
+__pycache__/

--- a/.odoo-work-cli.toml
+++ b/.odoo-work-cli.toml
@@ -1,10 +1,15 @@
 bundesland = "Baden-Württemberg"
 
+# Secrets for the odoo-erp DEV environment (issue #48).
+# api-key authenticates XML-RPC; password + totp_secret drive the
+# JSON-RPC web session used for attendance clock in/out.
 [op_secrets]
-url      = "op://Employee/Digitalgedacht Odoo/url"
-database = "op://Employee/Digitalgedacht Odoo/database-name"
-username = "op://Employee/Digitalgedacht Odoo/login"
-password = "op://Employee/Digitalgedacht Odoo/api-key"
+url         = "op://Employee/ODOO Work CLI/url"
+database    = "op://Employee/ODOO Work CLI/database-name"
+username    = "op://Employee/ODOO Work CLI/login"
+api-key     = "op://Employee/ODOO Work CLI/api-key"
+password    = "op://Employee/ODOO Work CLI/password"
+totp_secret = "op://Employee/ODOO Work CLI/totp_secret"
 
 [hours]
 daily_low = 6.0

--- a/1p.env
+++ b/1p.env
@@ -1,0 +1,11 @@
+# 1Password template for the odoo-erp DEV environment (issue #48).
+# Generate the local .env with: mise run prepare_env
+ODOO_URL="op://Employee/ODOO Work CLI/url"
+ODOO_DATABASE="op://Employee/ODOO Work CLI/database-name"
+ODOO_USERNAME="op://Employee/ODOO Work CLI/login"
+# XML-RPC auth (API key required because 2FA is enabled)
+ODOO_PASSWORD="op://Employee/ODOO Work CLI/api-key"
+# real login password — used for the JSON-RPC web session (clock in/out)
+ODOO_WEB_PASSWORD="op://Employee/ODOO Work CLI/password"
+# base32 TOTP secret for completing the web-session 2FA challenge
+ODOO_TOTP_SECRET="op://Employee/ODOO Work CLI/totp_secret"

--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,14 @@ description = "Build and run the CLI (pass args after --)"
 depends = ["build"]
 run = "./odoo-work-cli {{arg(i=0, var=true)}}"
 
+[tasks.prepare_env]
+description = "Generate .env from 1Password (op inject on 1p.env)"
+run = """
+op inject -f -i 1p.env -o .env
+chmod 600 .env
+echo ".env written from 1p.env"
+"""
+
 [tasks.test]
 description = "Run all tests"
 run = "go test ./..."

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,14 @@ op = "latest"
 gh = "latest"
 goreleaser = "latest"
 
+[env]
+# Dev-environment credentials, generated from 1p.env via `mise run prepare_env`.
+_.file = ".env"
+
+[task_config]
+# File tasks: scripts/tasks/odoo/<name> becomes task "odoo:<name>".
+includes = ["scripts/tasks"]
+
 [tasks.build]
 description = "Build the CLI binary"
 run = """
@@ -28,6 +36,15 @@ op inject -f -i 1p.env -o .env
 chmod 600 .env
 echo ".env written from 1p.env"
 """
+
+[tasks."odoo:prepare-db"]
+description = "Bootstrap the dev database: create API key, refresh .env, add test data"
+# Each step is a fresh `mise run` so it picks up the .env the previous step wrote.
+run = [
+    "mise run odoo:create-api-key",
+    "mise run prepare_env",
+    "mise run odoo:add-test-data",
+]
 
 [tasks.test]
 description = "Run all tests"

--- a/scripts/tasks/odoo/add-test-data
+++ b/scripts/tasks/odoo/add-test-data
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+#MISE description="Populate the Odoo dev database with the test environment the CLI config expects"
+#USAGE flag "--company <name>" help="Company name the config filters expect" default="digitalgedacht GmbH"
+#USAGE flag "--project <name>" help="Project name the config filters expect" default="Infrastruktur und Betrieb"
+#USAGE flag "--stage <name>" help="Task stage name the config filters expect" default="Umsetzung"
+
+"""Bootstrap the odoo-work-cli dev database for integration testing.
+
+Idempotent: safe to run repeatedly. Aligns the fresh dev database with
+what the checked-in ``.odoo-work-cli.toml`` filters and extra fields
+assume, and installs what the attendance commands need:
+
+* installs ``hr_attendance`` (clock in/out) if missing
+* enables the Project Stages feature (``project.group_project_stages``)
+  -- without it even admin gets an AccessError reading
+  ``project.project.stage_id``
+* renames the main company to match the company filters
+* creates the ``x_studio_productowner`` field on project.project
+  (mirrors the Studio field that exists on prod)
+* creates the filtered project, its task stages, and sample tasks
+* links an ``hr.employee`` to the CLI user (required for attendance)
+
+Required environment (see 1p.env / ``mise run prepare_env``):
+    ODOO_URL, ODOO_DATABASE, ODOO_USERNAME, ODOO_PASSWORD (API key)
+"""
+
+import os
+import ssl
+import sys
+import xmlrpc.client
+
+
+def env(name):
+    value = os.environ.get(name, "")
+    if not value:
+        sys.exit(f"error: {name} is not set (run: mise run prepare_env)")
+    return value
+
+
+def ssl_context():
+    ctx = ssl.create_default_context()
+    if not ctx.get_ca_certs() and os.path.exists("/etc/ssl/cert.pem"):
+        ctx = ssl.create_default_context(cafile="/etc/ssl/cert.pem")
+    return ctx
+
+
+class OdooXMLRPC:
+    """Thin XML-RPC wrapper bound to one database and user."""
+
+    def __init__(self, url, database, username, api_key):
+        ctx = ssl_context()
+        self.database = database
+        self.api_key = api_key
+        common = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common", context=ctx)
+        self.uid = common.authenticate(database, username, api_key, {})
+        if not self.uid:
+            sys.exit("error: XML-RPC authentication failed (stale ODOO_PASSWORD api key? run: mise run odoo:create-api-key)")
+        self.models = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/object", context=ctx)
+
+    def call(self, model, method, *args, **kwargs):
+        return self.models.execute_kw(
+            self.database, self.uid, self.api_key, model, method, list(args), kwargs
+        )
+
+    def find(self, model, domain, fields=("id",)):
+        return self.call(model, "search_read", domain, fields=list(fields), limit=1)
+
+
+def step(message):
+    print(f"* {message}")
+
+
+def ensure_module(odoo, name):
+    mod = odoo.find("ir.module.module", [["name", "=", name]], ("id", "state"))
+    if not mod:
+        sys.exit(f"error: module {name} not found on the server")
+    if mod[0]["state"] == "installed":
+        step(f"module {name}: already installed")
+        return
+    step(f"module {name}: installing (takes a while) ...")
+    odoo.call("ir.module.module", "button_immediate_install", [mod[0]["id"]])
+    step(f"module {name}: installed")
+
+
+def ensure_project_stages_feature(odoo):
+    group = odoo.find(
+        "ir.model.data",
+        [["module", "=", "project"], ["name", "=", "group_project_stages"]],
+        ("res_id",),
+    )
+    if group and odoo.find(
+        "res.users", [["id", "=", odoo.uid], ["groups_id", "in", [group[0]["res_id"]]]]
+    ):
+        step("project stages feature: already enabled")
+        return
+    settings_id = odoo.call("res.config.settings", "create", {"group_project_stages": True})
+    odoo.call("res.config.settings", "execute", [settings_id])
+    step("project stages feature: enabled")
+
+
+def ensure_company(odoo, name):
+    company = odoo.find("res.company", [["name", "=", name]])
+    if company:
+        step(f"company '{name}': exists")
+        return company[0]["id"]
+    main_id = odoo.call("res.company", "search", [], limit=1, order="id asc")[0]
+    odoo.call("res.company", "write", [main_id], {"name": name})
+    step(f"company '{name}': renamed main company (id {main_id})")
+    return main_id
+
+
+def ensure_productowner_field(odoo):
+    if odoo.find("ir.model.fields", [["model", "=", "project.project"], ["name", "=", "x_studio_productowner"]]):
+        step("field x_studio_productowner: exists")
+        return
+    model = odoo.find("ir.model", [["model", "=", "project.project"]])
+    odoo.call(
+        "ir.model.fields",
+        "create",
+        {
+            "name": "x_studio_productowner",
+            "model_id": model[0]["id"],
+            "ttype": "many2one",
+            "relation": "res.users",
+            "field_description": "Product Owner",
+        },
+    )
+    step("field x_studio_productowner: created on project.project")
+
+
+def ensure_project(odoo, name, company_id):
+    project = odoo.find("project.project", [["name", "=", name]])
+    if project:
+        pid = project[0]["id"]
+        step(f"project '{name}': exists (id {pid})")
+    else:
+        pid = odoo.call(
+            "project.project",
+            "create",
+            {"name": name, "company_id": company_id, "allow_timesheets": True},
+        )
+        step(f"project '{name}': created (id {pid})")
+    odoo.call("project.project", "write", [pid], {"x_studio_productowner": odoo.uid})
+    return pid
+
+
+def ensure_task_stages(odoo, project_id, filter_stage):
+    stage_ids = {}
+    for sequence, name in enumerate(["Backlog", filter_stage, "Erledigt"], start=1):
+        stage = odoo.find("project.task.type", [["name", "=", name]])
+        if stage:
+            sid = stage[0]["id"]
+            odoo.call("project.task.type", "write", [sid], {"project_ids": [[4, project_id]]})
+            step(f"task stage '{name}': exists (id {sid})")
+        else:
+            sid = odoo.call(
+                "project.task.type",
+                "create",
+                {"name": name, "sequence": sequence, "project_ids": [[4, project_id]]},
+            )
+            step(f"task stage '{name}': created (id {sid})")
+        stage_ids[name] = sid
+    return stage_ids
+
+
+def ensure_tasks(odoo, project_id, stage_id):
+    for name in ["Cluster Wartung", "Monitoring einrichten", "Backup prüfen"]:
+        task = odoo.find("project.task", [["name", "=", name], ["project_id", "=", project_id]])
+        if task:
+            odoo.call("project.task", "write", [task[0]["id"]], {"stage_id": stage_id})
+            step(f"task '{name}': exists (id {task[0]['id']})")
+            continue
+        tid = odoo.call(
+            "project.task",
+            "create",
+            {"name": name, "project_id": project_id, "stage_id": stage_id},
+        )
+        step(f"task '{name}': created (id {tid})")
+
+
+def ensure_employee(odoo, company_id):
+    employee = odoo.find("hr.employee", [["user_id", "=", odoo.uid]])
+    if employee:
+        step(f"employee for uid {odoo.uid}: exists (id {employee[0]['id']})")
+        return
+    user = odoo.call("res.users", "read", [odoo.uid], fields=["name"])
+    eid = odoo.call(
+        "hr.employee",
+        "create",
+        {"name": user[0]["name"], "user_id": odoo.uid, "company_id": company_id},
+    )
+    step(f"employee for uid {odoo.uid}: created (id {eid})")
+
+
+def main():
+    company_name = os.environ.get("usage_company", "digitalgedacht GmbH")
+    project_name = os.environ.get("usage_project", "Infrastruktur und Betrieb")
+    stage_name = os.environ.get("usage_stage", "Umsetzung")
+
+    odoo = OdooXMLRPC(env("ODOO_URL"), env("ODOO_DATABASE"), env("ODOO_USERNAME"), env("ODOO_PASSWORD"))
+    print(f"connected to {os.environ['ODOO_URL']} db={odoo.database} uid={odoo.uid}\n")
+
+    for module in ["project", "hr_timesheet", "hr_attendance"]:
+        ensure_module(odoo, module)
+    ensure_project_stages_feature(odoo)
+    company_id = ensure_company(odoo, company_name)
+    ensure_productowner_field(odoo)
+    project_id = ensure_project(odoo, project_name, company_id)
+    stages = ensure_task_stages(odoo, project_id, stage_name)
+    ensure_tasks(odoo, project_id, stages[stage_name])
+    ensure_employee(odoo, company_id)
+
+    print("\ntest environment ready")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tasks/odoo/create-api-key
+++ b/scripts/tasks/odoo/create-api-key
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+#MISE description="Create an Odoo XML-RPC API key for the dev user (via web login + 2FA)"
+#USAGE flag "--key-name <name>" help="Description stored on the API key" default="odoo-work-cli dev"
+#USAGE flag "--no-update-op" help="Only print the key; do not write it to the 1Password item"
+#USAGE flag "--op-item <item>" help="1Password item to update" default="ODOO Work CLI"
+#USAGE flag "--op-vault <vault>" help="1Password vault holding the item" default="Employee"
+
+"""Create an Odoo API key for XML-RPC access on the dev environment.
+
+Logs in via the HTML web flow (``/web/login`` -> ``/web/login/totp``),
+which is the only flow that binds the session to a database on the
+multi-db dev server, then drives the ``res.users.apikeys.description``
+wizard and its ``res.users.identitycheck`` confirmation.
+
+Required environment (see 1p.env / ``mise run prepare_env``):
+    ODOO_URL, ODOO_DATABASE, ODOO_USERNAME, ODOO_WEB_PASSWORD
+    ODOO_TOTP_SECRET (only when 2FA is enabled on the user)
+
+By default the new key is written back to the 1Password item so that
+``mise run prepare_env`` picks it up; pass --no-update-op to just print it.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import ssl
+import struct
+import subprocess
+import sys
+import time
+import urllib.request
+from http.cookiejar import CookieJar
+from urllib.parse import urlencode
+
+CSRF_RE = re.compile(r'name="csrf_token"[^>]*value="([^"]+)"')
+
+
+def env(name, required=True):
+    value = os.environ.get(name, "")
+    if required and not value:
+        sys.exit(f"error: {name} is not set (run: mise run prepare_env)")
+    return value
+
+
+def ssl_context():
+    ctx = ssl.create_default_context()
+    if not ctx.get_ca_certs() and os.path.exists("/etc/ssl/cert.pem"):
+        ctx = ssl.create_default_context(cafile="/etc/ssl/cert.pem")
+    return ctx
+
+
+def totp_code(secret):
+    key = base64.b32decode(secret.replace(" ", "").upper())
+    h = hmac.new(key, struct.pack(">Q", int(time.time()) // 30), hashlib.sha1).digest()
+    offset = h[19] & 0xF
+    return "%06d" % ((struct.unpack(">I", h[offset : offset + 4])[0] & 0x7FFFFFFF) % 1000000)
+
+
+class OdooWebSession:
+    """Minimal authenticated Odoo web session (HTML login flow + call_kw)."""
+
+    def __init__(self, base_url, database):
+        self.base = base_url.rstrip("/")
+        self.database = database
+        self.opener = urllib.request.build_opener(
+            urllib.request.HTTPSHandler(context=ssl_context()),
+            urllib.request.HTTPCookieProcessor(CookieJar()),
+        )
+
+    def get(self, path):
+        with self.opener.open(self.base + path, timeout=60) as resp:
+            return resp.geturl(), resp.read().decode()
+
+    def post_form(self, path, data):
+        req = urllib.request.Request(self.base + path, data=urlencode(data).encode())
+        with self.opener.open(req, timeout=60) as resp:
+            return resp.geturl(), resp.read().decode()
+
+    def login(self, username, password, totp_secret):
+        _, page = self.get(f"/web/login?db={self.database}")
+        csrf = CSRF_RE.search(page).group(1)
+        url, page = self.post_form(
+            "/web/login",
+            {"csrf_token": csrf, "login": username, "password": password, "redirect": ""},
+        )
+        if "/web/login/totp" in url:
+            if not totp_secret:
+                sys.exit("error: 2FA is enabled but ODOO_TOTP_SECRET is not set")
+            csrf = CSRF_RE.search(page).group(1)
+            url, _ = self.post_form(
+                "/web/login/totp",
+                {"csrf_token": csrf, "totp_token": totp_code(totp_secret), "redirect": ""},
+            )
+            if "totp" in url:
+                sys.exit("error: TOTP challenge failed (wrong ODOO_TOTP_SECRET or clock skew?)")
+        elif "/web/login" in url:
+            sys.exit("error: login failed (wrong ODOO_USERNAME/ODOO_WEB_PASSWORD?)")
+
+    def call_kw(self, model, method, args, kwargs=None):
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "call",
+            "id": 1,
+            "params": {"model": model, "method": method, "args": args, "kwargs": kwargs or {"context": {}}},
+        }
+        req = urllib.request.Request(
+            self.base + "/web/dataset/call_kw",
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with self.opener.open(req, timeout=60) as resp:
+            body = json.load(resp)
+        if body.get("error"):
+            err = body["error"]
+            msg = err.get("data", {}).get("message") or err.get("message")
+            raise RuntimeError(f"{model}.{method}: {msg}")
+        return body.get("result")
+
+
+def create_api_key(session, key_name, password, totp_secret):
+    wizard_id = session.call_kw("res.users.apikeys.description", "create", [{"name": key_name}])
+    result = session.call_kw("res.users.apikeys.description", "make_key", [[wizard_id]])
+
+    # make_key is @check_identity-guarded: it may hand back the identity
+    # check wizard instead of the key. Confirm with the password (some
+    # builds validate a TOTP code instead).
+    if isinstance(result, dict) and result.get("res_model") == "res.users.identitycheck":
+        check_id = result["res_id"]
+        session.call_kw("res.users.identitycheck", "write", [[check_id], {"password": password}])
+        try:
+            result = session.call_kw("res.users.identitycheck", "run_check", [[check_id]])
+        except RuntimeError:
+            session.call_kw(
+                "res.users.identitycheck",
+                "write",
+                [[check_id], {"password": totp_code(totp_secret)}],
+            )
+            result = session.call_kw("res.users.identitycheck", "run_check", [[check_id]])
+
+    key = (result.get("context") or {}).get("default_key") if isinstance(result, dict) else None
+    if not key:
+        sys.exit(f"error: no key in wizard result: {json.dumps(result)[:300]}")
+    return key
+
+
+def update_1password(item, vault, key):
+    cmd = ["op", "item", "edit", item, f"api-key={key}", "--vault", vault]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.exit(f"error: op item edit failed: {proc.stderr.strip()}")
+
+
+def main():
+    key_name = os.environ.get("usage_key_name", "odoo-work-cli dev")
+    update_op = os.environ.get("usage_no_update_op", "false") != "true"
+    op_item = os.environ.get("usage_op_item", "ODOO Work CLI")
+    op_vault = os.environ.get("usage_op_vault", "Employee")
+
+    url = env("ODOO_URL")
+    database = env("ODOO_DATABASE")
+    username = env("ODOO_USERNAME")
+    password = env("ODOO_WEB_PASSWORD")
+    totp_secret = env("ODOO_TOTP_SECRET", required=False)
+
+    print(f"logging in to {url} db={database} as {username} ...", file=sys.stderr)
+    session = OdooWebSession(url, database)
+    session.login(username, password, totp_secret)
+
+    key = create_api_key(session, key_name, password, totp_secret)
+    print(f"created API key {key[:6]}... ({key_name})", file=sys.stderr)
+
+    if update_op:
+        update_1password(op_item, op_vault, key)
+        print(f"updated 1Password item '{op_item}' field api-key", file=sys.stderr)
+        print("run 'mise run prepare_env' to refresh .env", file=sys.stderr)
+    else:
+        print(key)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #48

## What

Points the local test setup at the **odoo-erp dev environment** and adds tooling to bootstrap it from scratch.

- **`1p.env` + `prepare_env` task** — 1Password template (op:// refs only) that generates the local `.env` via `op inject`; mise auto-loads `.env` for all tasks, so `mise run run -- whoami` works out of the box
- **`.odoo-work-cli.toml`** — `[op_secrets]` now references the `ODOO Work CLI` 1Password item with the full key set: `api-key` (XML-RPC), `password` (web session for clock in/out), `totp_secret` (2FA)
- **`odoo:create-api-key`** — mise file task: logs in via the web flow (incl. TOTP 2FA challenge), creates an XML-RPC API key through the `res.users.apikeys` wizard + identity check, writes it back to 1Password
- **`odoo:add-test-data`** — idempotent mise file task: installs `hr_attendance`, enables the Project Stages feature, and creates the company, project, task stages, tasks and employee record the checked-in config filters expect
- **`odoo:prepare-db`** — chains `create-api-key` → `prepare_env` → `add-test-data` so a nuked dev db can be rebootstrapped in one command

Background: the dev user has 2FA enabled, so XML-RPC requires an API key (password auth silently returns `false`). The scripts use the HTML login flow because the JSON `/web/session/authenticate` route does not bind the session to a database on the multi-db dev server.

## Verified

- `odoo:prepare-db` ran end-to-end against dev (key created + stored in 1Password, db bootstrapped, re-run is a no-op)
- `whoami`, `projects`, `tasks`, `timesheets`, `entries add/update/delete`, `clock status` all work against dev
- Go test suite passes (except `TestRenderGrid_HighlightsWholeSelectedRow`, which also fails on `develop`)

## Out of scope / follow-up

- `clock in|out` still fails against dev: `internal/odoo/jsonrpc.go` fetches `/web/login/totp` without binding the session to a db first, which 404s on the multi-db server. Fix tracked in #48.
- readme/docs update for the new setup flow.