### PR TITLE
feat(tui): show daily and weekly attendance totals in header (#35)

### DIFF
--- a/internal/app/deps_test.go
+++ b/internal/app/deps_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"testing"
+	"time"
 
 	"github.com/seletz/odoo-work-cli/internal/config"
 	"github.com/seletz/odoo-work-cli/internal/odoo"
@@ -60,6 +61,10 @@ func (s *stubClient) ClockOut() (*odoo.AttendanceRecord, error) {
 }
 
 func (s *stubClient) AttendanceStatus() (*odoo.AttendanceStatus, error) {
+	return nil, nil
+}
+
+func (s *stubClient) ListAttendance(time.Time, time.Time) ([]odoo.AttendanceRecord, error) {
 	return nil, nil
 }
 

--- a/internal/odoo/attendance.go
+++ b/internal/odoo/attendance.go
@@ -126,28 +126,41 @@ func fetchAttendanceStatus(searchFn attendanceSearchFunc, empID int64, now time.
 	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	tomorrowStart := todayStart.AddDate(0, 0, 1)
 
+	all, err := fetchAttendanceRange(searchFn, empID, todayStart, tomorrowStart)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildAttendanceStatus(all, now)
+}
+
+// fetchAttendanceRange queries raw attendance records for [from, to).
+// It fetches records checked in within the range plus any still-open
+// records that started before the range (check_out = false), so that
+// attendance spanning midnight is correctly included.
+func fetchAttendanceRange(searchFn attendanceSearchFunc, empID int64, from, to time.Time) ([]map[string]interface{}, error) {
 	opts := goOdoo.NewOptions().
 		FetchFields("id", "employee_id", "check_in", "check_out", "worked_hours")
 
-	// Query 1: records checked in today.
-	todayCriteria := goOdoo.NewCriteria().
+	// Query 1: records checked in within the range.
+	rangeCriteria := goOdoo.NewCriteria().
 		Add("employee_id", "=", empID).
-		Add("check_in", ">=", todayStart.Format(odooDatetimeFormat)).
-		Add("check_in", "<", tomorrowStart.Format(odooDatetimeFormat))
+		Add("check_in", ">=", from.Format(odooDatetimeFormat)).
+		Add("check_in", "<", to.Format(odooDatetimeFormat))
 
-	records, err := searchFn("hr.attendance", todayCriteria, opts)
+	records, err := searchFn("hr.attendance", rangeCriteria, opts)
 	if IsNotFound(err) {
 		records = nil
 	} else if err != nil {
-		return nil, fmt.Errorf("fetching today's attendance: %w", err)
+		return nil, fmt.Errorf("fetching attendance: %w", err)
 	}
 
-	// Query 2: open records from previous days (check_in before today,
+	// Query 2: open records from before the range (check_in before from,
 	// check_out = false). This catches overnight attendance that started
 	// before midnight.
 	openCriteria := goOdoo.NewCriteria().
 		Add("employee_id", "=", empID).
-		Add("check_in", "<", todayStart.Format(odooDatetimeFormat)).
+		Add("check_in", "<", from.Format(odooDatetimeFormat)).
 		Add("check_out", "=", false)
 
 	openRecords, err := searchFn("hr.attendance", openCriteria, opts)
@@ -157,10 +170,52 @@ func fetchAttendanceStatus(searchFn attendanceSearchFunc, empID int64, now time.
 		return nil, fmt.Errorf("fetching open attendance: %w", err)
 	}
 
-	// Merge: open records first, then today's records.
-	all := append(openRecords, records...)
+	// Merge: open records first, then in-range records.
+	return append(openRecords, records...), nil
+}
 
-	return buildAttendanceStatus(all, now)
+// listAttendanceRecords fetches and parses attendance records for [from, to).
+func listAttendanceRecords(searchFn attendanceSearchFunc, empID int64, from, to time.Time) ([]AttendanceRecord, error) {
+	raw, err := fetchAttendanceRange(searchFn, empID, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]AttendanceRecord, 0, len(raw))
+	for _, r := range raw {
+		rec, err := parseAttendanceRecord(r)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, *rec)
+	}
+	return records, nil
+}
+
+// ListAttendance returns the current employee's attendance records with
+// check_in in [from, to), plus any still-open records that started before
+// the range (midnight wrap).
+func (x *XMLRPCClient) ListAttendance(from, to time.Time) ([]AttendanceRecord, error) {
+	empID, err := x.findEmployeeID()
+	if err != nil {
+		return nil, err
+	}
+	return listAttendanceRecords(x.searchReadRaw, empID, from, to)
+}
+
+// SumAttendanceHours totals worked hours across attendance records.
+// Closed records contribute their WorkedHours; open records contribute
+// the elapsed time from check-in until now.
+func SumAttendanceHours(records []AttendanceRecord, now time.Time) float64 {
+	var total float64
+	for _, r := range records {
+		if r.CheckOut == nil {
+			total += now.Sub(r.CheckIn).Hours()
+		} else {
+			total += r.WorkedHours
+		}
+	}
+	return total
 }
 
 // buildAttendanceStatus processes raw Odoo attendance records into an

--- a/internal/odoo/attendance_test.go
+++ b/internal/odoo/attendance_test.go
@@ -448,6 +448,147 @@ func TestBuildAttendanceStatus_NormalDay(t *testing.T) {
 	}
 }
 
+func TestSumAttendanceHours(t *testing.T) {
+	now := time.Date(2026, 3, 10, 14, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		records []AttendanceRecord
+		want    float64
+	}{
+		{
+			name:    "empty",
+			records: nil,
+			want:    0,
+		},
+		{
+			name: "closed records sum worked hours",
+			records: []AttendanceRecord{
+				{WorkedHours: 4.0, CheckIn: time.Date(2026, 3, 9, 8, 0, 0, 0, time.UTC), CheckOut: ptrTime(time.Date(2026, 3, 9, 12, 0, 0, 0, time.UTC))},
+				{WorkedHours: 3.5, CheckIn: time.Date(2026, 3, 10, 8, 0, 0, 0, time.UTC), CheckOut: ptrTime(time.Date(2026, 3, 10, 11, 30, 0, 0, time.UTC))},
+			},
+			want: 7.5,
+		},
+		{
+			name: "open record counts elapsed until now",
+			records: []AttendanceRecord{
+				{CheckIn: time.Date(2026, 3, 10, 13, 0, 0, 0, time.UTC)},
+			},
+			want: 1.0,
+		},
+		{
+			name: "mixed closed and open",
+			records: []AttendanceRecord{
+				{WorkedHours: 4.0, CheckIn: time.Date(2026, 3, 10, 8, 0, 0, 0, time.UTC), CheckOut: ptrTime(time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC))},
+				{CheckIn: time.Date(2026, 3, 10, 13, 30, 0, 0, time.UTC)},
+			},
+			want: 4.5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SumAttendanceHours(tt.records, now)
+			if got < tt.want-0.01 || got > tt.want+0.01 {
+				t.Errorf("SumAttendanceHours = %f, want %f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListAttendanceRecords_InRange(t *testing.T) {
+	// Two closed records within the week range.
+	rangeRecords := []map[string]interface{}{
+		{
+			"id":           int64(70),
+			"employee_id":  []interface{}{int64(7), "Test User"},
+			"check_in":     "2026-03-09 08:00:00",
+			"check_out":    "2026-03-09 16:00:00",
+			"worked_hours": float64(8.0),
+		},
+		{
+			"id":           int64(71),
+			"employee_id":  []interface{}{int64(7), "Test User"},
+			"check_in":     "2026-03-10 08:00:00",
+			"check_out":    "2026-03-10 12:00:00",
+			"worked_hours": float64(4.0),
+		},
+	}
+
+	searchFn := fakeSearchFn(rangeRecords, nil)
+	from := time.Date(2026, 3, 9, 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 0, 7)
+
+	records, err := listAttendanceRecords(searchFn, 7, from, to)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records len = %d, want 2", len(records))
+	}
+	if records[0].ID != 70 || records[1].ID != 71 {
+		t.Errorf("record IDs = %d, %d, want 70, 71", records[0].ID, records[1].ID)
+	}
+}
+
+func TestListAttendanceRecords_MidnightWrap(t *testing.T) {
+	// An open record that started before the range (overnight from the
+	// previous Sunday) must be included via the open-records pass.
+	openRecords := []map[string]interface{}{
+		{
+			"id":           int64(80),
+			"employee_id":  []interface{}{int64(7), "Test User"},
+			"check_in":     "2026-03-08 23:30:00",
+			"check_out":    false,
+			"worked_hours": float64(0),
+		},
+	}
+
+	searchFn := fakeSearchFn(nil, openRecords)
+	from := time.Date(2026, 3, 9, 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 0, 7)
+
+	records, err := listAttendanceRecords(searchFn, 7, from, to)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records len = %d, want 1", len(records))
+	}
+	if records[0].ID != 80 {
+		t.Errorf("record ID = %d, want 80", records[0].ID)
+	}
+	if records[0].CheckOut != nil {
+		t.Error("expected open record (CheckOut = nil)")
+	}
+}
+
+func TestListAttendanceRecords_QueryRange(t *testing.T) {
+	// Verify the range boundaries appear in the search criteria.
+	var captured []string
+	searchFn := func(_ string, criteria *goOdoo.Criteria, _ *goOdoo.Options) ([]map[string]interface{}, error) {
+		captured = append(captured, fmt.Sprintf("%v", *criteria))
+		return nil, nil
+	}
+
+	from := time.Date(2026, 3, 9, 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 0, 7)
+
+	if _, err := listAttendanceRecords(searchFn, 7, from, to); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 queries, got %d", len(captured))
+	}
+	if !strings.Contains(captured[0], "2026-03-09 00:00:00") ||
+		!strings.Contains(captured[0], "2026-03-16 00:00:00") {
+		t.Errorf("range query criteria = %q, want from/to bounds", captured[0])
+	}
+	if !strings.Contains(captured[1], "check_out") ||
+		!strings.Contains(captured[1], "2026-03-09 00:00:00") {
+		t.Errorf("open query criteria = %q, want check_out filter with from bound", captured[1])
+	}
+}
+
 // ptrTime returns a pointer to the given time.Time.
 func ptrTime(t time.Time) *time.Time {
 	return &t

--- a/internal/odoo/client.go
+++ b/internal/odoo/client.go
@@ -121,4 +121,7 @@ type Client interface {
 	ClockOut() (*AttendanceRecord, error)
 	// AttendanceStatus returns the current clock state and today's periods.
 	AttendanceStatus() (*AttendanceStatus, error)
+	// ListAttendance returns attendance records with check_in in [from, to),
+	// plus any still-open records that started before the range.
+	ListAttendance(from, to time.Time) ([]AttendanceRecord, error)
 }

--- a/internal/odoo/verify_attendance_dev_test.go
+++ b/internal/odoo/verify_attendance_dev_test.go
@@ -1,0 +1,89 @@
+//go:build devverify
+
+package odoo
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestDevVerify_ListAttendance manually verifies ListAttendance against the
+// dev environment. Run with:
+//
+//	go test -tags devverify -run TestDevVerify_ListAttendance -v ./internal/odoo/
+func TestDevVerify_ListAttendance(t *testing.T) {
+	url := os.Getenv("ODOO_URL")
+	if url == "" {
+		t.Skip("ODOO_URL not set")
+	}
+	client, err := NewXMLRPCClient(url, os.Getenv("ODOO_DATABASE"),
+		os.Getenv("ODOO_USERNAME"), os.Getenv("ODOO_PASSWORD"),
+		os.Getenv("ODOO_WEB_PASSWORD"), os.Getenv("ODOO_TOTP_SECRET"), nil)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer client.Close()
+
+	now := time.Now()
+	// Monday of the current week.
+	offset := (int(now.Weekday()) + 6) % 7
+	from := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -offset)
+	to := from.AddDate(0, 0, 7)
+
+	empID, err := client.findEmployeeID()
+	if err != nil {
+		t.Fatalf("findEmployeeID: %v", err)
+	}
+
+	// Seed: one closed record inside the week, one open record that started
+	// before the week (midnight wrap). The dev user is an admin, so direct
+	// XML-RPC creates on hr.attendance are allowed.
+	create := func(fields map[string]interface{}) int64 {
+		ids, err := client.client.Create("hr.attendance", []interface{}{fields}, nil)
+		if err != nil || len(ids) == 0 {
+			t.Fatalf("creating hr.attendance: %v", err)
+		}
+		return ids[0]
+	}
+	closedID := create(map[string]interface{}{
+		"employee_id": empID,
+		"check_in":    from.Add(32 * time.Hour).Format(odooDatetimeFormat), // Tue 08:00
+		"check_out":   from.Add(36 * time.Hour).Format(odooDatetimeFormat), // Tue 12:00
+	})
+	openID := create(map[string]interface{}{
+		"employee_id": empID,
+		"check_in":    from.Add(-time.Hour).Format(odooDatetimeFormat), // Sun 23:00
+	})
+	defer func() {
+		if err := client.client.Delete("hr.attendance", []int64{closedID, openID}); err != nil {
+			t.Errorf("cleanup unlink failed: %v", err)
+		}
+	}()
+
+	records, err := client.ListAttendance(from, to)
+	if err != nil {
+		t.Fatalf("ListAttendance: %v", err)
+	}
+	t.Logf("week %s..%s: %d records, total %.2f h",
+		from.Format("2006-01-02"), to.Format("2006-01-02"),
+		len(records), SumAttendanceHours(records, now))
+	for _, r := range records {
+		out := "open"
+		if r.CheckOut != nil {
+			out = r.CheckOut.Format("2006-01-02 15:04")
+		}
+		t.Logf("  #%d %s -> %s (%.2f h)", r.ID, r.CheckIn.Format("2006-01-02 15:04"), out, r.WorkedHours)
+	}
+
+	found := map[int64]bool{}
+	for _, r := range records {
+		found[r.ID] = true
+	}
+	if !found[closedID] {
+		t.Errorf("closed in-week record %d missing from ListAttendance result", closedID)
+	}
+	if !found[openID] {
+		t.Errorf("open midnight-wrap record %d missing from ListAttendance result", openID)
+	}
+}

--- a/internal/odoo/whoami_test.go
+++ b/internal/odoo/whoami_test.go
@@ -3,6 +3,7 @@ package odoo
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 // mockClient implements Client for testing.
@@ -22,12 +23,14 @@ type mockClient struct {
 	updateErr  error
 	deleteErr  error
 
-	clockInID        int64
-	clockInErr       error
-	clockOutRecord   *AttendanceRecord
-	clockOutErr      error
-	attendanceStatus *AttendanceStatus
-	attendanceErr    error
+	clockInID         int64
+	clockInErr        error
+	clockOutRecord    *AttendanceRecord
+	clockOutErr       error
+	attendanceStatus  *AttendanceStatus
+	attendanceErr     error
+	attendanceRecords []AttendanceRecord
+	attendanceListErr error
 }
 
 func (m *mockClient) WhoAmI() (*UserInfo, error) {
@@ -82,6 +85,10 @@ func (m *mockClient) ClockOut() (*AttendanceRecord, error) {
 
 func (m *mockClient) AttendanceStatus() (*AttendanceStatus, error) {
 	return m.attendanceStatus, m.attendanceErr
+}
+
+func (m *mockClient) ListAttendance(_, _ time.Time) ([]AttendanceRecord, error) {
+	return m.attendanceRecords, m.attendanceListErr
 }
 
 func TestWhoAmI_Success(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -57,6 +57,7 @@ type timesheetsLoadedMsg struct {
 // attendanceLoadedMsg is sent when attendance status finishes loading.
 type attendanceLoadedMsg struct {
 	status *odoo.AttendanceStatus
+	week   []odoo.AttendanceRecord // displayed week's attendance records
 	err    error
 }
 
@@ -88,30 +89,31 @@ type attendanceTickMsg time.Time
 
 // Model is the bubbletea model for the weekly timesheet TUI.
 type Model struct {
-	state        uiState
-	client       odoo.Client
-	grid         WeekGrid
-	monday       MondayTime
-	cursor       [2]int // [row, col]
-	spinner      spinner.Model
-	help         help.Model
-	keys         KeyMap
-	limits       config.HoursLimits
-	bundesland   string
-	holidays     HolidayMap
-	weekHols     [7]string
-	attendance   *odoo.AttendanceStatus
-	loading      bool
-	err          error
-	width        int
-	height       int
-	detailCursor int             // selected entry row in detail view
-	editIndex    int             // index into current day's entries slice
-	editHours    textinput.Model // hours input
-	editDesc     textinput.Model // description input
-	editFocus    int             // 0=hours, 1=description
-	editErr      error           // last edit error
-	editIsNew    bool            // true = creating new entry, false = editing existing
+	state          uiState
+	client         odoo.Client
+	grid           WeekGrid
+	monday         MondayTime
+	cursor         [2]int // [row, col]
+	spinner        spinner.Model
+	help           help.Model
+	keys           KeyMap
+	limits         config.HoursLimits
+	bundesland     string
+	holidays       HolidayMap
+	weekHols       [7]string
+	attendance     *odoo.AttendanceStatus
+	weekAttendance []odoo.AttendanceRecord // displayed week's attendance records
+	loading        bool
+	err            error
+	width          int
+	height         int
+	detailCursor   int             // selected entry row in detail view
+	editIndex      int             // index into current day's entries slice
+	editHours      textinput.Model // hours input
+	editDesc       textinput.Model // description input
+	editFocus      int             // 0=hours, 1=description
+	editErr        error           // last edit error
+	editIsNew      bool            // true = creating new entry, false = editing existing
 
 	helpPrevState uiState // state to return to when exiting help
 
@@ -187,9 +189,15 @@ func (m Model) loadTimesheets() tea.Cmd {
 
 func (m Model) loadAttendance() tea.Cmd {
 	client := m.client
+	from := time.Date(m.monday.Year(), m.monday.Month(), m.monday.Day(), 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 0, 7)
 	return func() tea.Msg {
 		status, err := client.AttendanceStatus()
-		return attendanceLoadedMsg{status: status, err: err}
+		if err != nil {
+			return attendanceLoadedMsg{err: err}
+		}
+		week, err := client.ListAttendance(from, to)
+		return attendanceLoadedMsg{status: status, week: week, err: err}
 	}
 }
 
@@ -270,6 +278,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case attendanceLoadedMsg:
 		if msg.err == nil {
 			m.attendance = msg.status
+			m.weekAttendance = msg.week
 		}
 		if m.attendance != nil && m.attendance.ClockedIn {
 			return m, attendanceTick()
@@ -289,10 +298,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.attendance = msg.status
+		// Reload attendance to refresh the displayed week's records.
 		if m.attendance != nil && m.attendance.ClockedIn {
-			return m, attendanceTick()
+			return m, tea.Batch(m.loadAttendance(), attendanceTick())
 		}
-		return m, nil
+		return m, m.loadAttendance()
 
 	case editSavedMsg:
 		if msg.err != nil {
@@ -389,7 +399,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.monday = MondayTime{m.monday.AddDate(0, 0, -7)}
 			m.loading = true
-			return m, tea.Batch(m.spinner.Tick, m.loadTimesheets())
+			return m, tea.Batch(m.spinner.Tick, m.loadTimesheets(), m.loadAttendance())
 
 		case key.Matches(msg, m.keys.Right):
 			if m.state == stateDetail {
@@ -397,7 +407,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.monday = MondayTime{m.monday.AddDate(0, 0, 7)}
 			m.loading = true
-			return m, tea.Batch(m.spinner.Tick, m.loadTimesheets())
+			return m, tea.Batch(m.spinner.Tick, m.loadTimesheets(), m.loadAttendance())
 		}
 
 		if m.state == stateGrid {
@@ -885,7 +895,7 @@ func (m Model) View() tea.View {
 		s = fmt.Sprintf("\n  Error: %s\n\n  Press 'r' to retry or 'q' to quit.\n\n", m.err)
 
 	case stateGrid, stateDetail, stateEdit, stateSearch, stateHelp:
-		headerBar := RenderHeaderBar(m.monday.Time, m.attendance, m.loading, m.spinner, m.width)
+		headerBar := RenderHeaderBar(m.monday.Time, m.attendance, m.weekAttendance, m.loading, m.spinner, m.width)
 		grid := RenderGrid(m.grid, m.cursor[0], m.cursor[1], m.width-4, m.limits, m.weekHols, m.companyColors, todayCol)
 		statusBar := RenderStatusBar(m.state, m.grid.WeekTotal, m.limits, m.attendance, m.width)
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -41,6 +41,10 @@ type mockClient struct {
 	clockOutErr     error
 	attendStatus    *odoo.AttendanceStatus
 	attendStatusErr error
+	attendWeek      []odoo.AttendanceRecord
+	attendWeekErr   error
+	attendWeekFrom  time.Time // capture last ListAttendance call
+	attendWeekTo    time.Time
 }
 
 func (c *mockClient) WhoAmI() (*odoo.UserInfo, error)            { return nil, nil }
@@ -90,6 +94,11 @@ func (c *mockClient) ClockOut() (*odoo.AttendanceRecord, error) {
 }
 func (c *mockClient) AttendanceStatus() (*odoo.AttendanceStatus, error) {
 	return c.attendStatus, c.attendStatusErr
+}
+func (c *mockClient) ListAttendance(from, to time.Time) ([]odoo.AttendanceRecord, error) {
+	c.attendWeekFrom = from
+	c.attendWeekTo = to
+	return c.attendWeek, c.attendWeekErr
 }
 
 func newTestModel(entries []odoo.TimesheetEntry, err error) Model {
@@ -1804,9 +1813,9 @@ func TestModel_ClockToggleMsgUpdatesClockedOut(t *testing.T) {
 	if um.attendance.ClockedIn {
 		t.Error("expected ClockedIn=false")
 	}
-	// Should not start tick when clocked out.
-	if cmd != nil {
-		t.Error("expected no tick command when clocked out")
+	// Should still reload attendance (week records changed on clock out).
+	if cmd == nil {
+		t.Error("expected attendance reload command after clock out")
 	}
 }
 
@@ -1967,4 +1976,98 @@ func TestModel_SearchAddedRowRemovedAfterEntryExists(t *testing.T) {
 	})
 	// No assertion on pendingRows internals, just verify grid has BrandNew.
 	// (The row now comes from server data, not pending rows.)
+}
+
+// execCmd runs a tea.Cmd, recursively executing nested batch commands so
+// that side effects on the mock client (captured calls) take place.
+func execCmd(cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, fn := range batch {
+			execCmd(fn)
+		}
+	}
+}
+
+func TestModel_AttendanceLoadedStoresWeekRecords(t *testing.T) {
+	m := newTestModel(nil, nil)
+	m.state = stateDetail
+
+	out := time.Date(2026, 3, 9, 16, 0, 0, 0, time.UTC)
+	msg := attendanceLoadedMsg{
+		status: &odoo.AttendanceStatus{ClockedIn: false},
+		week: []odoo.AttendanceRecord{
+			{ID: 1, CheckIn: out.Add(-8 * time.Hour), CheckOut: &out, WorkedHours: 8.0},
+		},
+	}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if len(um.weekAttendance) != 1 {
+		t.Fatalf("weekAttendance len = %d, want 1", len(um.weekAttendance))
+	}
+	if um.state != stateDetail {
+		t.Fatalf("expected stateDetail to be preserved, got %d", um.state)
+	}
+}
+
+func TestLoadAttendance_FetchesDisplayedWeek(t *testing.T) {
+	client := &mockClient{
+		attendStatus: &odoo.AttendanceStatus{},
+		attendWeek:   []odoo.AttendanceRecord{{ID: 5}},
+	}
+	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+
+	msg := m.loadAttendance()()
+	am, ok := msg.(attendanceLoadedMsg)
+	if !ok {
+		t.Fatalf("expected attendanceLoadedMsg, got %T", msg)
+	}
+	if am.err != nil {
+		t.Fatalf("unexpected error: %v", am.err)
+	}
+	if len(am.week) != 1 {
+		t.Fatalf("week len = %d, want 1", len(am.week))
+	}
+
+	wantFrom := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	if !client.attendWeekFrom.Equal(wantFrom) {
+		t.Errorf("from = %v, want %v", client.attendWeekFrom, wantFrom)
+	}
+	if !client.attendWeekTo.Equal(wantFrom.AddDate(0, 0, 7)) {
+		t.Errorf("to = %v, want %v", client.attendWeekTo, wantFrom.AddDate(0, 0, 7))
+	}
+}
+
+func TestModel_WeekNavReloadsAttendance(t *testing.T) {
+	client := &mockClient{attendStatus: &odoo.AttendanceStatus{}}
+	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+	m.state = stateGrid
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'l'})
+	execCmd(cmd)
+
+	wantFrom := time.Date(2026, 3, 9, 0, 0, 0, 0, time.UTC)
+	if !client.attendWeekFrom.Equal(wantFrom) {
+		t.Errorf("attendance reload from = %v, want next week %v", client.attendWeekFrom, wantFrom)
+	}
+}
+
+func TestModel_ClockToggleReloadsWeekAttendance(t *testing.T) {
+	client := &mockClient{attendStatus: &odoo.AttendanceStatus{}}
+	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+	m.state = stateGrid
+
+	_, cmd := m.Update(clockToggleMsg{status: &odoo.AttendanceStatus{ClockedIn: false}})
+	execCmd(cmd)
+
+	if client.attendWeekFrom.IsZero() {
+		t.Fatal("expected ListAttendance to be called after clock toggle")
+	}
 }

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -27,8 +27,8 @@ const (
 )
 
 // RenderHeaderBar renders a styled top header bar with app name, week number,
-// date range, clock status, and loading indicator.
-func RenderHeaderBar(monday time.Time, attendance *odoo.AttendanceStatus, loading bool, spin spinner.Model, width int) string {
+// date range, clock status, attendance totals, and loading indicator.
+func RenderHeaderBar(monday time.Time, attendance *odoo.AttendanceStatus, weekAttendance []odoo.AttendanceRecord, loading bool, spin spinner.Model, width int) string {
 	sunday := monday.AddDate(0, 0, 6)
 	_, isoWeek := monday.ISOWeek()
 
@@ -44,8 +44,11 @@ func RenderHeaderBar(monday time.Time, attendance *odoo.AttendanceStatus, loadin
 		loadingIndicator = " " + spin.View()
 	}
 
-	clockStatus := renderClockStatus(attendance)
-	right := clockStatus + loadingIndicator + " "
+	right := renderClockStatus(attendance)
+	if summary := renderAttendanceSummary(attendance, weekAttendance, time.Now()); summary != "" {
+		right += "  " + summary
+	}
+	right += loadingIndicator + " "
 
 	// Manually pad to full width so we don't rely on lipgloss Width wrapping
 	// (which can break with nested ANSI sequences).
@@ -238,7 +241,7 @@ func RenderGrid(grid WeekGrid, cursorRow, cursorCol, width int, limits config.Ho
 						cell = todayCellStyle.Render(cell)
 					}
 				}
-				if rowSelected && !(li == 0 && d == cursorCol) {
+				if rowSelected && (li != 0 || d != cursorCol) {
 					cell = rowCursorStyle.Render(cell)
 				}
 				line += gridSepStyle.Render(boxV) + cell
@@ -490,6 +493,30 @@ func renderClockStatus(attendance *odoo.AttendanceStatus) string {
 	text := fmt.Sprintf("● In %s (%d:%02d)",
 		attendance.CheckIn.Local().Format("15:04"), h, m)
 	return clockedInStyle.Render(text)
+}
+
+// renderAttendanceSummary returns styled daily and weekly attendance totals,
+// e.g. "Today 6:30 · Week 32:15". Today covers the current day's periods
+// (from the attendance status), Week covers the displayed week's records.
+// Open periods contribute elapsed time up to now.
+func renderAttendanceSummary(attendance *odoo.AttendanceStatus, week []odoo.AttendanceRecord, now time.Time) string {
+	if attendance == nil {
+		return ""
+	}
+	today := odoo.SumAttendanceHours(attendance.Periods, now)
+	weekTotal := odoo.SumAttendanceHours(week, now)
+	text := fmt.Sprintf("Today %s · Week %s",
+		formatHoursOrZero(today), formatHoursOrZero(weekTotal))
+	return attendanceSummaryStyle.Render(text)
+}
+
+// formatHoursOrZero formats hours as "H:MM", rendering zero as "0:00"
+// instead of the empty string FormatHours returns.
+func formatHoursOrZero(h float64) string {
+	if s := FormatHours(h); s != "" {
+		return s
+	}
+	return "0:00"
 }
 
 // renderEditForm renders the edit form overlay content.

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"charm.land/bubbles/v2/spinner"
 	"github.com/seletz/odoo-work-cli/internal/config"
 	"github.com/seletz/odoo-work-cli/internal/odoo"
 )
@@ -196,5 +198,96 @@ func TestRenderGrid_HighlightsWholeSelectedRow(t *testing.T) {
 	}
 	if !strings.Contains(out, selectedTotal) {
 		t.Fatal("output should highlight the selected row total")
+	}
+}
+
+func TestRenderAttendanceSummary(t *testing.T) {
+	now := time.Date(2026, 3, 10, 14, 0, 0, 0, time.UTC)
+	checkIn := now.Add(-time.Hour)
+
+	closed := func(day int, hours float64) odoo.AttendanceRecord {
+		in := time.Date(2026, 3, day, 8, 0, 0, 0, time.UTC)
+		out := in.Add(time.Duration(hours * float64(time.Hour)))
+		return odoo.AttendanceRecord{CheckIn: in, CheckOut: &out, WorkedHours: hours}
+	}
+
+	tests := []struct {
+		name       string
+		attendance *odoo.AttendanceStatus
+		week       []odoo.AttendanceRecord
+		want       []string
+		wantEmpty  bool
+	}{
+		{
+			name:       "nil attendance renders nothing",
+			attendance: nil,
+			wantEmpty:  true,
+		},
+		{
+			name: "closed periods and week records",
+			attendance: &odoo.AttendanceStatus{
+				Periods: []odoo.AttendanceRecord{closed(10, 6.5)},
+			},
+			week: []odoo.AttendanceRecord{closed(9, 30.0), closed(10, 2.25)},
+			want: []string{"Today 6:30", "Week 32:15"},
+		},
+		{
+			name: "open period counts elapsed time",
+			attendance: &odoo.AttendanceStatus{
+				ClockedIn: true,
+				CheckIn:   &checkIn,
+				Periods:   []odoo.AttendanceRecord{{CheckIn: checkIn}},
+			},
+			week: []odoo.AttendanceRecord{{CheckIn: checkIn}},
+			want: []string{"Today 1:00", "Week 1:00"},
+		},
+		{
+			name:       "no records shows zero totals",
+			attendance: &odoo.AttendanceStatus{},
+			week:       nil,
+			want:       []string{"Today 0:00", "Week 0:00"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := renderAttendanceSummary(tt.attendance, tt.week, now)
+			if tt.wantEmpty {
+				if out != "" {
+					t.Fatalf("expected empty string, got %q", out)
+				}
+				return
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(out, want) {
+					t.Errorf("output %q should contain %q", out, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderHeaderBar_ShowsAttendanceTotals(t *testing.T) {
+	mon := monday(2026, 3, 9)
+	checkIn := time.Now().Add(-30 * time.Minute)
+	attendance := &odoo.AttendanceStatus{
+		ClockedIn: true,
+		CheckIn:   &checkIn,
+		Periods:   []odoo.AttendanceRecord{{CheckIn: checkIn}},
+	}
+	weekOut := checkIn.Add(-time.Hour)
+	week := []odoo.AttendanceRecord{
+		{CheckIn: weekOut.Add(-8 * time.Hour), CheckOut: &weekOut, WorkedHours: 8.0},
+		{CheckIn: checkIn},
+	}
+
+	s := spinner.New()
+	out := RenderHeaderBar(mon, attendance, week, false, s, 160)
+
+	if !strings.Contains(out, "Today 0:30") {
+		t.Errorf("header %q should contain today's attendance total", out)
+	}
+	if !strings.Contains(out, "Week 8:30") {
+		t.Errorf("header %q should contain weekly attendance total", out)
 	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -95,6 +95,9 @@ var (
 	clockedInStyle  = lipgloss.NewStyle().Foreground(colorGreen).Bold(true)
 	clockedOutStyle = lipgloss.NewStyle().Foreground(colorRed)
 
+	// Daily/weekly attendance totals in the header bar.
+	attendanceSummaryStyle = lipgloss.NewStyle().Faint(true)
+
 	detailHintStyle      = lipgloss.NewStyle().Faint(true)
 	editLabelStyle       = lipgloss.NewStyle().Faint(true)
 	editActiveLabelStyle = lipgloss.NewStyle().Bold(true)


### PR DESCRIPTION
Fixes #35

## What

The TUI header bar now shows attendance totals at a glance, next to the existing clock-in indicator:

```
 W29  Mon 13 Jul 2026 — Sun 19 Jul 2026        ● In 09:04 (2:15)  Today 6:30 · Week 32:15
```

- **Today** — the current day's attendance total (same data as `clock status`), including elapsed time of an open period.
- **Week** — the attendance total of the **displayed** week, so paging with `h`/`l` shows past/future weeks' attendance alongside the timesheet grid.

## How

- New `Client.ListAttendance(from, to)` returns attendance records with `check_in` in `[from, to)` **plus** any still-open records that started before the range — the same two-pass midnight-wrap handling as the daily status query, extracted into a shared `fetchAttendanceRange` helper.
- New pure helper `SumAttendanceHours(records, now)` totals closed records' `worked_hours` and counts open periods up to `now`.
- The existing attendance data flow is extended rather than duplicated: `attendanceLoadedMsg` now also carries the displayed week's records, `loadAttendance` fetches both, and the handler preserves the current UI state. The week's attendance reloads on week navigation, refresh (`r`), and after clock in/out. Totals are computed at render time, so they tick along with the existing per-minute attendance ticker.

## Design notes

- "Today" always refers to the current day (like the clock status), independent of the displayed week; "Week" follows the displayed week.
- An open record that started before the displayed week contributes its full elapsed time to that week's total (pathological long-open records aren't split at week boundaries — kept consistent with how the daily status counts open periods).

## Testing

- TDD, table-driven tests for `SumAttendanceHours`, `listAttendanceRecords` (in-range, midnight wrap, query bounds), `renderAttendanceSummary`, header rendering, and model wiring (week-nav reload, clock-toggle reload, state preservation).
- Manually verified against the **dev** environment with a `devverify`-tagged test that seeds a closed in-week record plus an open midnight-wrap record, checks both appear in `ListAttendance`, and cleans up after itself.
- `mise run test` (only the pre-existing `TestRenderGrid_HighlightsWholeSelectedRow` failure remains), `mise run lint` (0 issues; includes a one-line staticcheck QF1001 fix in `RenderGrid`), `mise run fmt` clean.