### PR TITLE
fix(odoo): authenticate web session via HTML login flow for multi-db servers

### DIFF
--- a/internal/odoo/jsonrpc.go
+++ b/internal/odoo/jsonrpc.go
@@ -17,7 +17,7 @@ import (
 )
 
 // jsonRPCSession manages a JSON-RPC session with Odoo.
-// It handles authentication via /web/session/authenticate and
+// It authenticates through the HTML web login flow (/web/login) and
 // maintains session cookies for subsequent requests.
 // This is needed for controller endpoints (like attendance toggle)
 // that require an authenticated web session.
@@ -47,63 +47,62 @@ func newJSONRPCSession(baseURL, database, login, password, totpSecret string) *j
 	}
 }
 
-// authenticate performs JSON-RPC session authentication against Odoo.
-// When 2FA (TOTP) is enabled, the initial authenticate returns uid=false
-// and sets a pre_uid in the session. We then complete the TOTP challenge
-// by POSTing the generated code to /web/login/totp.
+// authenticate logs in through the HTML web login flow: GET
+// /web/login?db=<db> for the CSRF token, then POST the credentials to
+// /web/login. On multi-db servers this is the only flow that binds the
+// session to a database — the JSON /web/session/authenticate endpoint
+// leaves a 2FA-pending session unbound, so /web/login/totp is dispatched
+// in nodb mode and 404s (#54). When Odoo redirects to /web/login/totp,
+// the 2FA challenge is completed with a generated TOTP code.
 func (s *jsonRPCSession) authenticate() error {
-	payload := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      s.reqID.Add(1),
-		"method":  "call",
-		"params": map[string]interface{}{
-			"db":       s.database,
-			"login":    s.login,
-			"password": s.password,
-		},
+	// GET /web/login?db=<db> binds the session to the database
+	// (ensure_db) and yields the CSRF token for the login form.
+	csrfToken, err := s.fetchCSRFToken("/web/login?db=" + url.QueryEscape(s.database))
+	if err != nil {
+		return fmt.Errorf("fetching login form: %w", err)
 	}
 
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("marshalling auth request: %w", err)
+	// POST credentials without following redirects: a redirect means the
+	// credentials were accepted (to /web/login/totp when 2FA is pending),
+	// a 200 means the login form was re-rendered with an error.
+	form := url.Values{
+		"csrf_token": {csrfToken},
+		"login":      {s.login},
+		"password":   {s.password},
+		"redirect":   {""},
 	}
-
-	resp, err := s.httpClient.Post(s.baseURL+"/web/session/authenticate", "application/json", bytes.NewReader(body))
+	resp, err := s.noRedirectClient().PostForm(s.baseURL+"/web/login", form)
 	if err != nil {
-		return fmt.Errorf("authenticating: %w", err)
+		return fmt.Errorf("submitting login form: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	var result struct {
-		Error *struct {
-			Message string                 `json:"message"`
-			Data    map[string]interface{} `json:"data"`
-		} `json:"error"`
-		Result map[string]interface{} `json:"result"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("decoding auth response: %w", err)
-	}
-	if result.Error != nil {
-		msg := result.Error.Message
-		if data, ok := result.Error.Data["message"].(string); ok {
-			msg = data
-		}
-		return fmt.Errorf("authentication failed: %s", msg)
-	}
-
-	// Odoo returns uid: false when 2FA is required (pre_uid set in session).
-	if uid, ok := result.Result["uid"]; ok {
-		if uid == false || uid == nil {
-			if s.totpSecret != "" {
-				return s.completeTOTP()
+	switch resp.StatusCode {
+	case http.StatusSeeOther, http.StatusFound:
+		if strings.Contains(resp.Header.Get("Location"), "/web/login/totp") {
+			if s.totpSecret == "" {
+				return fmt.Errorf("authentication failed: 2FA is enabled but no TOTP secret configured (set totp_secret in [op_secrets] or ODOO_TOTP_SECRET env var)")
 			}
-			return fmt.Errorf("authentication failed: 2FA is enabled but no TOTP secret configured (set totp_secret in [op_secrets] or ODOO_TOTP_SECRET env var)")
+			return s.completeTOTP()
 		}
+		s.authenticated = true
+		return nil
+	case http.StatusOK:
+		return fmt.Errorf("authentication failed: Odoo rejected the login (the web session needs the login password, not the API key)")
+	default:
+		return fmt.Errorf("authentication failed: unexpected status %d from /web/login", resp.StatusCode)
 	}
+}
 
-	s.authenticated = true
-	return nil
+// noRedirectClient returns a client sharing the session cookie jar that
+// does not follow redirects, so redirect status codes stay observable.
+func (s *jsonRPCSession) noRedirectClient() *http.Client {
+	return &http.Client{
+		Jar: s.httpClient.Jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 }
 
 // completeTOTP finishes the 2FA flow by generating a TOTP code and
@@ -123,20 +122,13 @@ func (s *jsonRPCSession) completeTOTP() error {
 		return fmt.Errorf("fetching CSRF token: %w", err)
 	}
 
-	// POST the TOTP code as form data. Use a non-redirecting client
-	// so we can distinguish success (302/303 redirect) from failure (200).
-	noRedirect := &http.Client{
-		Jar: s.httpClient.Jar,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-
+	// POST the TOTP code as form data. Success is a redirect (302/303),
+	// failure re-renders the form (200).
 	form := url.Values{
 		"csrf_token": {csrfToken},
 		"totp_token": {code},
 	}
-	totpResp, err := noRedirect.PostForm(s.baseURL+"/web/login/totp", form)
+	totpResp, err := s.noRedirectClient().PostForm(s.baseURL+"/web/login/totp", form)
 	if err != nil {
 		return fmt.Errorf("submitting TOTP code: %w", err)
 	}

--- a/internal/odoo/jsonrpc_test.go
+++ b/internal/odoo/jsonrpc_test.go
@@ -2,243 +2,323 @@ package odoo
 
 import (
 	"encoding/json"
-	"io"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
+
+	"github.com/pquerna/otp/totp"
 )
 
-func TestJSONRPCSession_Authenticate(t *testing.T) {
-	var gotBody map[string]interface{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/web/session/authenticate" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		if r.Method != http.MethodPost {
-			t.Errorf("unexpected method: %s", r.Method)
-		}
-		body, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(body, &gotBody)
+const (
+	testTOTPSecret = "JBSWY3DPEHPK3PXP"
+	mockLoginCSRF  = "mock-login-csrf"
+	mockTOTPCSRF   = "mock-totp-csrf"
+)
 
-		http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "abc123"})
-		resp := map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      1,
-			"result": map[string]interface{}{
-				"uid": float64(42),
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer srv.Close()
+// mockOdooServer simulates the Odoo web login endpoints, including the
+// multi-db behaviour (#54): with no dbfilter, routes like /web/login/totp
+// are dispatched in nodb mode and return 404 until the session is bound
+// to a database via GET /web/login?db=<db>. The legacy JSON endpoint
+// /web/session/authenticate does NOT bind the session when 2FA is
+// pending, which is exactly the bug the HTML login flow works around.
+type mockOdooServer struct {
+	*httptest.Server
 
-	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "secret123", "")
-	err := s.authenticate()
-	if err != nil {
+	multiDB    bool
+	totpSecret string // non-empty means 2FA is enabled for the user
+	db         string
+	login      string
+	password   string
+	callError  bool // make the attendance endpoint return a JSON-RPC error
+
+	mu            sync.Mutex
+	dbBound       bool
+	totpPending   bool
+	authenticated bool
+	loginForm     url.Values // last POST /web/login form values
+}
+
+func newMockOdooServer(t *testing.T, m *mockOdooServer) *mockOdooServer {
+	t.Helper()
+	m.Server = httptest.NewServer(http.HandlerFunc(m.handler))
+	t.Cleanup(m.Close)
+	return m
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func (m *mockOdooServer) handler(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch {
+	case r.URL.Path == "/web/session/authenticate":
+		// Legacy JSON auth. A single-db server binds the session as a
+		// side effect; a multi-db server with 2FA pending does not.
+		if !m.multiDB {
+			m.dbBound = true
+		}
+		if m.totpSecret != "" {
+			m.totpPending = true
+			writeJSON(w, map[string]interface{}{
+				"jsonrpc": "2.0", "id": 1,
+				"result": map[string]interface{}{"uid": false},
+			})
+			return
+		}
+		m.authenticated = true
+		writeJSON(w, map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1,
+			"result": map[string]interface{}{"uid": 42},
+		})
+
+	case r.URL.Path == "/web/login" && r.Method == http.MethodGet:
+		if r.URL.Query().Get("db") == m.db || !m.multiDB {
+			m.dbBound = true
+		}
+		if !m.dbBound {
+			http.Redirect(w, r, "/web/database/selector", http.StatusSeeOther)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<form><input type="hidden" name="csrf_token" value="%s"/></form>`, mockLoginCSRF)
+
+	case r.URL.Path == "/web/login" && r.Method == http.MethodPost:
+		if !m.dbBound {
+			http.NotFound(w, r)
+			return
+		}
+		_ = r.ParseForm()
+		m.loginForm = r.PostForm
+		if r.PostFormValue("csrf_token") != mockLoginCSRF {
+			http.Error(w, "invalid CSRF token", http.StatusBadRequest)
+			return
+		}
+		if r.PostFormValue("login") != m.login || r.PostFormValue("password") != m.password {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = fmt.Fprintf(w, `<form><input type="hidden" name="csrf_token" value="%s"/>Wrong login/password</form>`, mockLoginCSRF)
+			return
+		}
+		if m.totpSecret != "" {
+			m.totpPending = true
+			w.Header().Set("Location", "/web/login/totp")
+			w.WriteHeader(http.StatusSeeOther)
+			return
+		}
+		m.authenticated = true
+		w.Header().Set("Location", "/web")
+		w.WriteHeader(http.StatusSeeOther)
+
+	case r.URL.Path == "/web/login/totp" && r.Method == http.MethodGet:
+		if !m.dbBound {
+			http.NotFound(w, r) // nodb dispatch: the #54 symptom
+			return
+		}
+		if !m.totpPending {
+			http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<form><input type="hidden" name="csrf_token" value="%s"/></form>`, mockTOTPCSRF)
+
+	case r.URL.Path == "/web/login/totp" && r.Method == http.MethodPost:
+		if !m.dbBound {
+			http.NotFound(w, r)
+			return
+		}
+		_ = r.ParseForm()
+		if r.PostFormValue("csrf_token") != mockTOTPCSRF {
+			http.Error(w, "invalid CSRF token", http.StatusBadRequest)
+			return
+		}
+		if !m.totpPending || !totp.Validate(r.PostFormValue("totp_token"), m.totpSecret) {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = fmt.Fprintf(w, `<form><input type="hidden" name="csrf_token" value="%s"/>Invalid code</form>`, mockTOTPCSRF)
+			return
+		}
+		m.totpPending = false
+		m.authenticated = true
+		w.Header().Set("Location", "/web")
+		w.WriteHeader(http.StatusSeeOther)
+
+	case r.URL.Path == "/hr_attendance/systray_check_in_out":
+		if !m.authenticated {
+			writeJSON(w, map[string]interface{}{
+				"jsonrpc": "2.0", "id": 1,
+				"error": map[string]interface{}{
+					"code":    100,
+					"message": "Odoo Session Expired",
+					"data":    map[string]interface{}{"message": "Session expired"},
+				},
+			})
+			return
+		}
+		if m.callError {
+			writeJSON(w, map[string]interface{}{
+				"jsonrpc": "2.0", "id": 1,
+				"error": map[string]interface{}{
+					"code":    200,
+					"message": "Odoo Server Error",
+					"data":    map[string]interface{}{"message": "Something went wrong"},
+				},
+			})
+			return
+		}
+		writeJSON(w, map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1,
+			"result": map[string]interface{}{"attendance_state": "checked_in"},
+		})
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// TestJSONRPCSession_Authenticate_MultiDB_TOTP is the #54 regression test:
+// on a multi-db server the TOTP route 404s until the session is bound to
+// the database, so authentication must go through the HTML login flow.
+func TestJSONRPCSession_Authenticate_MultiDB_TOTP(t *testing.T) {
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:    true,
+		totpSecret: testTOTPSecret,
+		db:         "testdb",
+		login:      "user@test.com",
+		password:   "pass",
+	})
+
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "pass", testTOTPSecret)
+	if err := s.authenticate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !s.authenticated {
+		t.Error("expected client session authenticated = true")
+	}
+	if !m.authenticated {
+		t.Error("expected server session to be finalized")
+	}
+}
+
+// TestJSONRPCSession_Authenticate_SingleDB_TOTP guards the previously
+// working case: single-db servers must keep authenticating fine.
+func TestJSONRPCSession_Authenticate_SingleDB_TOTP(t *testing.T) {
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:    false,
+		totpSecret: testTOTPSecret,
+		db:         "testdb",
+		login:      "user@test.com",
+		password:   "pass",
+	})
+
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "pass", testTOTPSecret)
+	if err := s.authenticate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.authenticated {
+		t.Error("expected server session to be finalized")
+	}
+}
+
+func TestJSONRPCSession_Authenticate_NoTOTP(t *testing.T) {
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:  true,
+		db:       "testdb",
+		login:    "user@test.com",
+		password: "secret123",
+	})
+
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "secret123", "")
+	if err := s.authenticate(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !s.authenticated {
 		t.Error("expected authenticated = true")
 	}
 
-	// Verify request body structure.
-	params, _ := gotBody["params"].(map[string]interface{})
-	if params["db"] != "testdb" {
-		t.Errorf("db = %v, want testdb", params["db"])
+	// Verify the login form carried the credentials.
+	if got := m.loginForm.Get("login"); got != "user@test.com" {
+		t.Errorf("login = %q, want user@test.com", got)
 	}
-	if params["login"] != "user@test.com" {
-		t.Errorf("login = %v, want user@test.com", params["login"])
-	}
-	if params["password"] != "secret123" {
-		t.Errorf("password = %v, want secret123", params["password"])
+	if got := m.loginForm.Get("password"); got != "secret123" {
+		t.Errorf("password = %q, want secret123", got)
 	}
 }
 
-func TestJSONRPCSession_AuthenticateError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      1,
-			"error": map[string]interface{}{
-				"code":    200,
-				"message": "Odoo Server Error",
-				"data": map[string]interface{}{
-					"message": "Access Denied",
-				},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer srv.Close()
+func TestJSONRPCSession_Authenticate_WrongPassword(t *testing.T) {
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:  true,
+		db:       "testdb",
+		login:    "user@test.com",
+		password: "correct",
+	})
 
-	s := newJSONRPCSession(srv.URL, "testdb", "bad@test.com", "wrong", "")
-	err := s.authenticate()
-	if err == nil {
-		t.Fatal("expected error, got nil")
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "wrong", "")
+	if err := s.authenticate(); err == nil {
+		t.Fatal("expected error for wrong password, got nil")
+	}
+	if s.authenticated {
+		t.Error("expected authenticated = false")
 	}
 }
 
-func TestJSONRPCSession_AuthenticateUIDFalse_NoTOTP(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      1,
-			"result": map[string]interface{}{
-				"uid": false,
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer srv.Close()
+func TestJSONRPCSession_Authenticate_TOTPRequiredNoSecret(t *testing.T) {
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:    true,
+		totpSecret: testTOTPSecret,
+		db:         "testdb",
+		login:      "user@test.com",
+		password:   "pass",
+	})
 
-	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "pass", "")
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "pass", "")
 	err := s.authenticate()
 	if err == nil {
-		t.Fatal("expected error for uid=false without TOTP secret, got nil")
+		t.Fatal("expected error when 2FA is required without TOTP secret, got nil")
 	}
 	if got := err.Error(); got != "authentication failed: 2FA is enabled but no TOTP secret configured (set totp_secret in [op_secrets] or ODOO_TOTP_SECRET env var)" {
 		t.Errorf("unexpected error message: %s", got)
 	}
 }
 
-func TestJSONRPCSession_AuthenticateWithTOTP(t *testing.T) {
-	var totpPath string
-	var totpFormValues map[string]string
+func TestJSONRPCSession_Authenticate_TOTPWrongSecret(t *testing.T) {
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:    true,
+		totpSecret: testTOTPSecret,
+		db:         "testdb",
+		login:      "user@test.com",
+		password:   "pass",
+	})
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		switch r.URL.Path {
-		case "/web/session/authenticate":
-			// Return uid=false to trigger 2FA flow.
-			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "pre-auth-session"})
-			resp := map[string]interface{}{
-				"jsonrpc": "2.0",
-				"id":      1,
-				"result": map[string]interface{}{
-					"uid": false,
-				},
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-
-		case "/web/login/totp":
-			if r.Method == http.MethodGet {
-				// Return an HTML page with a CSRF token.
-				w.Header().Set("Content-Type", "text/html")
-				_, _ = w.Write([]byte(`<form><input type="hidden" name="csrf_token" value="test-csrf-42"/></form>`))
-				return
-			}
-			// POST: verify TOTP submission.
-			totpPath = r.URL.Path
-			_ = r.ParseForm()
-			totpFormValues = map[string]string{
-				"csrf_token": r.FormValue("csrf_token"),
-				"totp_token": r.FormValue("totp_token"),
-			}
-			// Simulate success: redirect to /web.
-			w.Header().Set("Location", "/web")
-			w.WriteHeader(http.StatusSeeOther)
-
-		default:
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-	}))
-	defer srv.Close()
-
-	// Use a known TOTP secret and verify that a code was submitted.
-	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "pass", "JBSWY3DPEHPK3PXP")
-	err := s.authenticate()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !s.authenticated {
-		t.Error("expected authenticated = true after TOTP")
-	}
-	if totpPath != "/web/login/totp" {
-		t.Errorf("TOTP path = %q, want /web/login/totp", totpPath)
-	}
-	if totpFormValues["csrf_token"] != "test-csrf-42" {
-		t.Errorf("csrf_token = %q, want test-csrf-42", totpFormValues["csrf_token"])
-	}
-	if totpFormValues["totp_token"] == "" {
-		t.Error("totp_token was empty, expected a generated code")
-	}
-}
-
-func TestJSONRPCSession_TOTPVerificationFailed(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/web/session/authenticate":
-			w.Header().Set("Content-Type", "application/json")
-			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "pre-auth"})
-			resp := map[string]interface{}{
-				"jsonrpc": "2.0",
-				"id":      1,
-				"result": map[string]interface{}{
-					"uid": false,
-				},
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-
-		case "/web/login/totp":
-			if r.Method == http.MethodGet {
-				w.Header().Set("Content-Type", "text/html")
-				_, _ = w.Write([]byte(`<form><input type="hidden" name="csrf_token" value="csrf-abc"/></form>`))
-				return
-			}
-			// Return 200 (form re-rendered) = verification failed.
-			w.Header().Set("Content-Type", "text/html")
-			_, _ = w.Write([]byte(`<form>Error: invalid code</form>`))
-		}
-	}))
-	defer srv.Close()
-
-	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "pass", "JBSWY3DPEHPK3PXP")
-	err := s.authenticate()
-	if err == nil {
+	// Client generates codes from a different secret than the server expects.
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "pass", "XYNHNRPRJMRNG6UP")
+	if err := s.authenticate(); err == nil {
 		t.Fatal("expected TOTP verification error, got nil")
+	}
+	if m.authenticated {
+		t.Error("expected server session to remain unauthenticated")
 	}
 }
 
 func TestJSONRPCSession_Call(t *testing.T) {
-	authCalled := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:    true,
+		totpSecret: testTOTPSecret,
+		db:         "testdb",
+		login:      "user@test.com",
+		password:   "pass",
+	})
 
-		if r.URL.Path == "/web/session/authenticate" {
-			authCalled = true
-			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "abc123"})
-			resp := map[string]interface{}{
-				"jsonrpc": "2.0",
-				"id":      1,
-				"result":  map[string]interface{}{"uid": float64(42)},
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-			return
-		}
-
-		if r.URL.Path != "/hr_attendance/systray_check_in_out" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-
-		resp := map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      2,
-			"result":  map[string]interface{}{"attendance_state": "checked_in"},
-		}
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer srv.Close()
-
-	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "secret123", "")
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "pass", testTOTPSecret)
 	result, err := s.call("/hr_attendance/systray_check_in_out", map[string]interface{}{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !authCalled {
+	if !m.authenticated {
 		t.Error("expected auto-authentication")
 	}
 	if result["attendance_state"] != "checked_in" {
@@ -247,36 +327,15 @@ func TestJSONRPCSession_Call(t *testing.T) {
 }
 
 func TestJSONRPCSession_CallErrorResponse(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:   true,
+		db:        "testdb",
+		login:     "user@test.com",
+		password:  "pass",
+		callError: true,
+	})
 
-		if r.URL.Path == "/web/session/authenticate" {
-			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "abc123"})
-			resp := map[string]interface{}{
-				"jsonrpc": "2.0",
-				"id":      1,
-				"result":  map[string]interface{}{"uid": float64(42)},
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-			return
-		}
-
-		resp := map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      2,
-			"error": map[string]interface{}{
-				"code":    200,
-				"message": "Odoo Server Error",
-				"data": map[string]interface{}{
-					"message": "Something went wrong",
-				},
-			},
-		}
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer srv.Close()
-
-	s := newJSONRPCSession(srv.URL, "testdb", "user@test.com", "secret123", "")
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "pass", "")
 	_, err := s.call("/hr_attendance/systray_check_in_out", map[string]interface{}{})
 	if err == nil {
 		t.Fatal("expected error, got nil")


### PR DESCRIPTION
Fixes #54

## Problem

On multi-db servers without a dbfilter (like the new dev odoo-erp instance), `clock in` / `clock out` and the TUI clock toggle fail with:

```
Error: toggling attendance: fetching CSRF token: CSRF token not found in /web/login/totp response
```

`POST /web/session/authenticate` (JSON) with 2FA pending leaves the session **unbound to a database**, so the follow-up `GET /web/login/totp` is dispatched in nodb mode and returns a plain 404 — hence no CSRF token. The previous production instance was single-db, which is why the old flow worked there.

## Fix

`jsonRPCSession.authenticate()` now uses the HTML web login flow instead of the JSON endpoint:

1. `GET /web/login?db=<db>` — binds the session to the database (`ensure_db`) and yields the CSRF token
2. `POST /web/login` with a non-redirecting client — a 303 to `/web/login/totp` means 2FA is pending (hand off to the existing `completeTOTP()`), a 303 elsewhere means success, a 200 means the credentials were rejected
3. `POST /web/login/totp` — unchanged TOTP completion

This is the same flow `scripts/tasks/odoo/create-api-key` already uses against the same server, and it works identically on single-db servers.

## Tests

New stateful mock Odoo server (`mockOdooServer`) in `internal/odoo/jsonrpc_test.go` reproduces the multi-db behaviour: `/web/login/totp` 404s until the session is db-bound via `/web/login?db=`. Before the fix, `TestJSONRPCSession_Authenticate_MultiDB_TOTP` failed with the exact production error (`CSRF token not found in /web/login/totp response`); a single-db regression test (`TestJSONRPCSession_Authenticate_SingleDB_TOTP`) guards the previously working case. Additional coverage: no-2FA login, wrong password, 2FA required without TOTP secret, wrong TOTP secret, auto-auth on `call()`.

`go test ./...` passes (except the known pre-existing `TestRenderGrid_HighlightsWholeSelectedRow`), `golangci-lint` reports 0 issues.

## Live verification on dev

Full write path verified against the dev instance (multi-db, 2FA enabled):

```
$ ./odoo-work-cli clock status
Status: Not clocked in
No attendance records today.

$ ./odoo-work-cli clock in
Clocked in at 11:48

$ ./odoo-work-cli clock status
#   Check In   Check Out  Duration
--- ---------- ---------- --------
1   11:48      --:--      0:00 (running)

$ ./odoo-work-cli clock out
Clocked out at 11:48
Duration: 0:00 (0.00h)

$ ./odoo-work-cli clock status
#   Check In   Check Out  Duration
--- ---------- ---------- --------
1   11:48      11:48      0:00
```

The test attendance records were deleted from the dev database afterwards (verified 0 remaining).