### PR TITLE
fix(tui): booked hours on other companies' projects no longer vanish (#58)

### DIFF
--- a/internal/app/deps_test.go
+++ b/internal/app/deps_test.go
@@ -36,6 +36,10 @@ func (s *stubClient) ListTimesheets(string, string) ([]odoo.TimesheetEntry, erro
 	return nil, nil
 }
 
+func (s *stubClient) ListAllTimesheets(string, string) ([]odoo.TimesheetEntry, error) {
+	return nil, nil
+}
+
 func (s *stubClient) GetFields(string) ([]odoo.FieldInfo, error) {
 	return nil, nil
 }

--- a/internal/odoo/client.go
+++ b/internal/odoo/client.go
@@ -104,8 +104,12 @@ type Client interface {
 	ListTasks(projectID int64) ([]TaskInfo, error)
 	// ListAllTasks returns tasks ignoring configured filters, optionally filtered by project ID.
 	ListAllTasks(projectID int64) ([]TaskInfo, error)
-	// ListTimesheets returns timesheet entries for the given date range.
+	// ListTimesheets returns timesheet entries for the given date range,
+	// applying configured filters.
 	ListTimesheets(dateFrom, dateTo string) ([]TimesheetEntry, error)
+	// ListAllTimesheets returns timesheet entries for the given date range,
+	// ignoring configured filters.
+	ListAllTimesheets(dateFrom, dateTo string) ([]TimesheetEntry, error)
 	// GetFields returns field metadata for the given Odoo model.
 	GetFields(model string) ([]FieldInfo, error)
 	// CreateTimesheet creates a new timesheet entry and returns its ID.

--- a/internal/odoo/filters_test.go
+++ b/internal/odoo/filters_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/seletz/odoo-work-cli/internal/config"
+	goOdoo "github.com/skilld-labs/go-odoo"
 )
 
 func TestFiltersForModel(t *testing.T) {
@@ -44,6 +45,66 @@ func TestFiltersForModel(t *testing.T) {
 		filters := x2.filtersForModel("task")
 		if filters != nil {
 			t.Errorf("expected nil, got %v", filters)
+		}
+	})
+}
+
+// criteriaFields extracts the field names from a criteria's criterions.
+func criteriaFields(t *testing.T, criteria *goOdoo.Criteria) []string {
+	t.Helper()
+	var fields []string
+	for _, c := range *criteria {
+		tuple, ok := c.([]interface{})
+		if !ok || len(tuple) < 1 {
+			t.Fatalf("unexpected criterion shape: %#v", c)
+		}
+		field, ok := tuple[0].(string)
+		if !ok {
+			t.Fatalf("unexpected criterion field type: %#v", tuple[0])
+		}
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+// Issue #58: timesheet entries booked on another company's project carry that
+// company's company_id. A configured [models.timesheet] company filter must
+// only be part of the domain when filters are requested.
+func TestTimesheetCriteria(t *testing.T) {
+	x := &XMLRPCClient{
+		login: "user@example.com",
+		models: map[string]config.ModelConfig{
+			"timesheet": {
+				Filters: []config.Filter{
+					{Field: "company_id.name", Op: "=", Value: "digitalgedacht GmbH"},
+				},
+			},
+		},
+	}
+
+	t.Run("filtered includes configured filters", func(t *testing.T) {
+		fields := criteriaFields(t, x.timesheetCriteria("2026-07-13", "2026-07-19", true))
+		want := []string{"date", "date", "user_id.login", "company_id.name"}
+		if len(fields) != len(want) {
+			t.Fatalf("criteria fields = %v, want %v", fields, want)
+		}
+		for i := range want {
+			if fields[i] != want[i] {
+				t.Errorf("fields[%d] = %q, want %q", i, fields[i], want[i])
+			}
+		}
+	})
+
+	t.Run("unfiltered omits configured filters", func(t *testing.T) {
+		fields := criteriaFields(t, x.timesheetCriteria("2026-07-13", "2026-07-19", false))
+		want := []string{"date", "date", "user_id.login"}
+		if len(fields) != len(want) {
+			t.Fatalf("criteria fields = %v, want %v", fields, want)
+		}
+		for i := range want {
+			if fields[i] != want[i] {
+				t.Errorf("fields[%d] = %q, want %q", i, fields[i], want[i])
+			}
 		}
 	})
 }

--- a/internal/odoo/whoami_test.go
+++ b/internal/odoo/whoami_test.go
@@ -59,6 +59,10 @@ func (m *mockClient) ListTimesheets(_, _ string) ([]TimesheetEntry, error) {
 	return m.timesheets, m.tsErr
 }
 
+func (m *mockClient) ListAllTimesheets(_, _ string) ([]TimesheetEntry, error) {
+	return m.timesheets, m.tsErr
+}
+
 func (m *mockClient) GetFields(_ string) ([]FieldInfo, error) {
 	return m.fields, m.fieldsErr
 }

--- a/internal/odoo/whoami_xmlrpc_test.go
+++ b/internal/odoo/whoami_xmlrpc_test.go
@@ -61,10 +61,10 @@ func extractRequestedFields(body string) []string {
 	return fields
 }
 
-// newMockOdooServer simulates an Odoo XML-RPC endpoint as seen by a
+// newMockXMLRPCServer simulates an Odoo XML-RPC endpoint as seen by a
 // non-admin user: reading res.users without a minimal field restriction
 // raises the res.users.log ACL fault.
-func newMockOdooServer(t *testing.T, requestedFields *[]string) *httptest.Server {
+func newMockXMLRPCServer(t *testing.T, requestedFields *[]string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -95,7 +95,7 @@ func newMockOdooServer(t *testing.T, requestedFields *[]string) *httptest.Server
 
 func TestWhoAmI_RequestsMinimalFields(t *testing.T) {
 	var requestedFields []string
-	server := newMockOdooServer(t, &requestedFields)
+	server := newMockXMLRPCServer(t, &requestedFields)
 	defer server.Close()
 
 	client, err := NewXMLRPCClient(server.URL, "testdb", "test@example.com", "api-key", "", "", nil)

--- a/internal/odoo/xmlrpc.go
+++ b/internal/odoo/xmlrpc.go
@@ -312,13 +312,36 @@ func (x *XMLRPCClient) listTasks(projectID int64, filtered bool) ([]TaskInfo, er
 	return result, nil
 }
 
-// ListTimesheets returns timesheet entries for the given date range.
-func (x *XMLRPCClient) ListTimesheets(dateFrom, dateTo string) ([]TimesheetEntry, error) {
+// timesheetCriteria builds the search domain for the user's timesheet
+// entries in the given date range. Configured [models.timesheet] filters
+// are only added when applyFilters is true.
+func (x *XMLRPCClient) timesheetCriteria(dateFrom, dateTo string, applyFilters bool) *goOdoo.Criteria {
 	criteria := goOdoo.NewCriteria().
 		Add("date", ">=", dateFrom).
 		Add("date", "<=", dateTo).
 		Add("user_id.login", "=", x.login)
-	x.applyCriteriaFilters(criteria, "timesheet")
+	if applyFilters {
+		x.applyCriteriaFilters(criteria, "timesheet")
+	}
+	return criteria
+}
+
+// ListTimesheets returns timesheet entries for the given date range,
+// applying configured filters.
+func (x *XMLRPCClient) ListTimesheets(dateFrom, dateTo string) ([]TimesheetEntry, error) {
+	return x.listTimesheets(dateFrom, dateTo, true)
+}
+
+// ListAllTimesheets returns timesheet entries for the given date range,
+// ignoring configured filters. Entries booked on another company's project
+// carry that company's company_id, so a configured company filter would
+// silently hide the user's own bookings (issue #58).
+func (x *XMLRPCClient) ListAllTimesheets(dateFrom, dateTo string) ([]TimesheetEntry, error) {
+	return x.listTimesheets(dateFrom, dateTo, false)
+}
+
+func (x *XMLRPCClient) listTimesheets(dateFrom, dateTo string, applyFilters bool) ([]TimesheetEntry, error) {
+	criteria := x.timesheetCriteria(dateFrom, dateTo, applyFilters)
 
 	fields := []string{"id", "date", "project_id", "task_id", "name", "unit_amount", "employee_id", "validated_status", "company_id"}
 	opts := goOdoo.NewOptions().FetchFields(fields...)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -171,7 +171,10 @@ func (m Model) loadTimesheets() tea.Cmd {
 	client := m.client
 	mondayStr := monday.Format("2006-01-02")
 	return func() tea.Msg {
-		entries, err := client.ListTimesheets(dateFrom, dateTo)
+		// Unfiltered fetch: the weekly grid must show all of the user's own
+		// bookings; configured [models.timesheet] filters would silently hide
+		// entries booked on another company's projects (issue #58).
+		entries, err := client.ListAllTimesheets(dateFrom, dateTo)
 		if err != nil {
 			return timesheetsLoadedMsg{err: err}
 		}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -18,6 +18,8 @@ import (
 // mockClient implements odoo.Client for testing.
 type mockClient struct {
 	entries         []odoo.TimesheetEntry
+	allEntries      []odoo.TimesheetEntry // ListAllTimesheets result (falls back to entries)
+	listAllTsCalled bool
 	err             error
 	updateErr       error
 	updatedID       int64
@@ -71,6 +73,13 @@ func (c *mockClient) ListAllTasks(_ int64) ([]odoo.TaskInfo, error) {
 func (c *mockClient) ListTimesheets(string, string) ([]odoo.TimesheetEntry, error) {
 	return c.entries, c.err
 }
+func (c *mockClient) ListAllTimesheets(string, string) ([]odoo.TimesheetEntry, error) {
+	c.listAllTsCalled = true
+	if c.allEntries != nil {
+		return c.allEntries, c.err
+	}
+	return c.entries, c.err
+}
 func (c *mockClient) CreateTimesheet(params odoo.TimesheetWriteParams) (int64, error) {
 	c.createParams = params
 	return c.createdID, c.createErr
@@ -105,6 +114,35 @@ func newTestModel(entries []odoo.TimesheetEntry, err error) Model {
 	client := &mockClient{entries: entries, err: err}
 	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
 	return NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+}
+
+// Issue #58: the weekly grid must show all of the user's own bookings,
+// including those on other companies' projects that configured
+// [models.timesheet] filters would exclude.
+func TestLoadTimesheets_UsesUnfilteredFetch(t *testing.T) {
+	client := &mockClient{
+		entries: []odoo.TimesheetEntry{
+			{Date: "2026-03-02", Project: "Intern", ProjectID: 1, Hours: 1},
+		},
+		allEntries: []odoo.TimesheetEntry{
+			{Date: "2026-03-02", Project: "Intern", ProjectID: 1, Hours: 1},
+			{Date: "2026-03-02", Project: "Siemens ITECS", ProjectID: 4, TaskID: 8, Company: "nexiles Test AG", Hours: 2},
+		},
+	}
+	mon := MondayTime{Time: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)}
+	m := NewModel(client, mon, config.DefaultHoursLimits(), "Deutschland", nil, nil)
+
+	msg := m.loadTimesheets()()
+	loaded, ok := msg.(timesheetsLoadedMsg)
+	if !ok {
+		t.Fatalf("expected timesheetsLoadedMsg, got %T", msg)
+	}
+	if !client.listAllTsCalled {
+		t.Error("expected loadTimesheets to use ListAllTimesheets so config filters cannot hide own entries")
+	}
+	if len(loaded.entries) != 2 {
+		t.Fatalf("len(entries) = %d, want 2 (foreign-company entry must not vanish)", len(loaded.entries))
+	}
 }
 
 func TestModel_LoadedTransitionsToGrid(t *testing.T) {

--- a/readme.md
+++ b/readme.md
@@ -324,6 +324,12 @@ Filters scope queries automatically. They are defined per model under
 `[models.<name>]` with `field`, `op`, and `value`. Supported operators include
 `=`, `!=`, `ilike`, `>`, `<`, `>=`, `<=`, etc.
 
+Note: the TUI weekly grid ignores `[models.timesheet]` filters and always
+shows all of your own bookings. Timesheet entries booked on another
+company's project carry that company's `company_id`, so a company filter
+would silently hide hours you just booked (see issue #58). The `entries`
+and `timesheets` commands still apply `[models.timesheet]` filters.
+
 ### Configurable key bindings
 
 TUI key bindings can be overridden in the `[keys]` section. Action names are


### PR DESCRIPTION
Fixes #58

## Root cause

Odoo assigns a timesheet line (`account.analytic.line`) the **project's** company, not the employee's. When hours are booked on a project owned by another company (nexiles / Siemens ITECS), the line gets that company's `company_id`.

A configured `[models.timesheet]` filter such as

```toml
[models.timesheet]
filters = [
    { field = "company_id.name", op = "=", value = "digitalgedacht GmbH" },
]
```

is AND-ed into the `ListTimesheets` search domain, so the server never returns those entries. The TUI grid therefore dropped the booking right after it was added; the row itself stayed visible because rows added via search are kept as pending rows across reloads — which produced the confusing "row present, all cells empty, totals wrong" symptom from the screenshot.

The alternative theory (missing `allowed_company_ids` context / multi-company record rules on XML-RPC reads) was tested and ruled out: an unfiltered fetch returns the foreign-company entry fine.

## Repro (dev environment)

1. Create a second company, add it to the user's allowed companies, create a project owned by it (`allow_timesheets`) plus a task, and an `hr.employee` for the user in that company.
2. `odoo-work-cli entries add --project-id <p> --task-id <t> --hours 2 --description x`
3. With the company filter above active: `entries --date <today>` and the TUI omit the entry (day total wrong); without the filter both show it.

## Fix

- New `Client.ListAllTimesheets(dateFrom, dateTo)` — same query without configured `[models.timesheet]` filters, mirroring the existing `ListAllProjects`/`ListAllTasks` pattern.
- The TUI weekly grid now loads via `ListAllTimesheets`: the grid is already scoped to the current user and week, and must always show all of the user's own bookings (its totals feed the hour-limit coloring).
- `entries` / `timesheets` CLI commands keep applying configured filters (documented feature); readme notes the TUI exception.
- Also fixes the `internal/odoo` test build on develop, broken by a duplicate `newMockOdooServer` helper from the #52/#56 merge.

## Verified

- TDD: `TestTimesheetCriteria` (domain with/without filters) and `TestLoadTimesheets_UsesUnfilteredFetch` (grid load path) — red before, green after.
- Live TUI against dev with the filter config: the `[NEX] A/26/0549 - Siemens ITECS / Core Tasks` row shows the booking in cell, day total and week total; detail view lists the entry.
- `go test ./...` (only the known pre-existing `TestRenderGrid_HighlightsWholeSelectedRow` failure remains), `golangci-lint`: 0 issues.