### PR TITLE
chore(mise): migrate run task off deprecated Tera arg() template

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -27,7 +27,8 @@ run = "scripts/release.sh"
 [tasks.run]
 description = "Build and run the CLI (pass args after --)"
 depends = ["build"]
-run = "./odoo-work-cli {{arg(i=0, var=true)}}"
+usage = 'arg "[args]" var=#true'
+run = "./odoo-work-cli"
 
 [tasks.prepare_env]
 description = "Generate .env from 1Password (op inject on 1p.env)"


### PR DESCRIPTION
Fixes #60

`mise run run` printed a deprecation warning because `[tasks.run]` used the deprecated Tera template function `arg()` in its run script.

**Before:**
```
$ mise run run -- --help
mise WARN  deprecated [tera_template_task_args]: Task 'run' uses deprecated Tera template functions (arg(), option(), flag()) in run scripts. Use the 'usage' field instead. See https://mise.en.dev/tasks/task-arguments.html This will be removed in mise 2027.5.0.
[build] $ ...
```

**After:**
```
$ mise run run -- --help
[build] $ ...
[run] $ ./odoo-work-cli --help
```

The variadic argument is now declared via the `usage` field (KDL v2 syntax, so `var=#true`); with no template in the run script, mise appends everything after `--` to the command, so behavior is unchanged.

Verified with mise 2026.7.5:
- `mise run run -- --help` and `mise run run -- entries --help` pass args through as before (quoting of multi-word args preserved)
- No `tera_template_task_args` warning on any task
- The `scripts/tasks/odoo/*` file tasks already use `#USAGE` directives and never triggered the warning
- `mise run test` / `lint` / `fmt` unaffected (one pre-existing TUI test failure, `TestRenderGrid_HighlightsWholeSelectedRow`, fails identically on the base commit and is unrelated)