### PR TITLE
test(tui): make selected-row highlight assertions width-independent

### DIFF
--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -1,12 +1,13 @@
 package tui
 
 import (
-	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"charm.land/bubbles/v2/spinner"
+	"charm.land/lipgloss/v2"
 	"github.com/seletz/odoo-work-cli/internal/config"
 	"github.com/seletz/odoo-work-cli/internal/odoo"
 )
@@ -177,6 +178,19 @@ func TestRenderGrid_WrapsLongLabels(t *testing.T) {
 	}
 }
 
+// stylePrefix returns the ANSI escape sequence a style emits before its
+// content, so highlight assertions do not depend on exact column widths.
+func stylePrefix(t *testing.T, s lipgloss.Style) string {
+	t.Helper()
+	const marker = "\x00"
+	rendered := s.Render(marker)
+	i := strings.Index(rendered, marker)
+	if i < 0 {
+		t.Fatalf("style output %q should contain marker", rendered)
+	}
+	return rendered[:i]
+}
+
 func TestRenderGrid_HighlightsWholeSelectedRow(t *testing.T) {
 	entries := []odoo.TimesheetEntry{
 		{Date: "2026-03-02", Project: "Alpha", Task: "Dev", Hours: 1.0},
@@ -186,18 +200,34 @@ func TestRenderGrid_HighlightsWholeSelectedRow(t *testing.T) {
 	g := BuildWeekGrid(entries, monday(2026, 3, 2))
 	out := RenderGrid(g, 1, 0, 120, config.DefaultHoursLimits(), [7]string{}, nil, -1)
 
-	selectedLabel := rowCursorStyle.Render(fmt.Sprintf("%-*s", 40, "Beta / QA"))
-	selectedCell := cursorStyle.Render(fmt.Sprintf("%*s", 9, "2:00"))
-	selectedTotal := rowCursorStyle.Render(totalsStyle.Render(fmt.Sprintf("%*s", 9, "2:00")))
+	var selectedLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Beta / QA") {
+			selectedLine = line
+			break
+		}
+	}
+	if selectedLine == "" {
+		t.Fatal("output should contain the selected row")
+	}
 
-	if !strings.Contains(out, selectedLabel) {
-		t.Fatal("output should highlight the selected row label")
+	// Label is left-aligned, so the row cursor sequence immediately
+	// precedes the label text.
+	if !strings.Contains(selectedLine, stylePrefix(t, rowCursorStyle)+"Beta / QA") {
+		t.Error("output should highlight the selected row label")
 	}
-	if !strings.Contains(out, selectedCell) {
-		t.Fatal("output should keep the selected cell highlighted")
+
+	// Cells are right-aligned; match the style sequence followed by
+	// padding and the hours, whatever the column width.
+	selectedCell := regexp.MustCompile(regexp.QuoteMeta(stylePrefix(t, cursorStyle)) + ` *2:00`)
+	if !selectedCell.MatchString(selectedLine) {
+		t.Error("output should keep the selected cell highlighted")
 	}
-	if !strings.Contains(out, selectedTotal) {
-		t.Fatal("output should highlight the selected row total")
+
+	selectedTotal := regexp.MustCompile(
+		regexp.QuoteMeta(stylePrefix(t, rowCursorStyle)+stylePrefix(t, totalsStyle)) + ` *2:00`)
+	if !selectedTotal.MatchString(selectedLine) {
+		t.Error("output should highlight the selected row total")
 	}
 }
 


### PR DESCRIPTION
Fixes #62

## Verdict: the test was broken, not the renderer

The rendered grid is correct. Debug-rendering the grid at the test's fixed size shows the selected cell carries `cursorStyle` byte-for-byte — the exact escape prefix `ESC[1;38;2;255;255;255;48;2;95;135;255m` — around the hours text. The only mismatch with the test's expected substring was padding width: the test hard-coded `fmt.Sprintf("%*s", 9, "2:00")` while the grid renders cells at width 8.

## Why it broke, and why the bisect was non-monotonic

- The test was authored in ff1465e (2026-03-12) against the pre-polish layout, where day cells were `colWidth` (= 9 at width 120) wide.
- The visual-polish PR #43 (ac9f739, 2026-03-15) changed cells to `colWidth-1` (= 8) and added box-drawing `│` separators — on a branch that did **not** contain the test yet. `git show ac9f739:internal/tui/render_test.go` has no `TestRenderGrid_HighlightsWholeSelectedRow`, so the reported "passes at ac9f739" was a vacuous pass (no matching test ran).
- The two lineages met in merge 2739d3f ("cleanup main"), whose renderer already uses `colWidth-1`. The test has failed on every commit where it coexists with the polished renderer — bisecting across the merge topology mixes commits that have the test (fail) with commits that don't (vacuous pass), which is exactly the non-monotonic behavior observed.
- The third assertion (`selectedTotal`, also width 9) was equally stale; it was just never reached because the second assertion `t.Fatal`s first.

Environment sensitivity was ruled out: lipgloss v2's `Style.Render` emits color sequences deterministically (no render-time profile detection), so no profile pinning is needed.

## Fix

Rewrite the assertions to test intent instead of exact column geometry: each check now matches the style's ANSI escape prefix (obtained by rendering a marker through the same style value the renderer uses) followed by right-aligned padding of any width and the expected hours text, on the selected row's line. Uses `t.Error` instead of `t.Fatal` so all three highlight checks report independently.

Verified the new test is not vacuous: mutating `RenderGrid` to drop the selected-cell highlight makes it fail with "output should keep the selected cell highlighted".

`mise run test` is fully green (removing the known pre-existing failure), `mise run lint` reports 0 issues.