### PR TITLE
feat(odoo): web-login version-drift canary + self-diagnosing auth errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,10 @@ There are now full **dev**, **test**, and **prod** environments of odoo-erp.
 
 - Development and testing **MUST ONLY** target the **dev** environment.
 - **test and prod MUST NOT be touched** by local development or automated tests.
+- **Before any Odoo upgrade reaches test/prod**: run `mise run odoo:login-canary`
+  against dev (dev gets new Odoo versions first). It verifies the web-login
+  flow internals encoded in `internal/odoo/jsonrpc.go` (see readme,
+  "Pre-upgrade check: web-login version-drift canary").
 
 ## Project Structure
 

--- a/internal/odoo/canary_dev_test.go
+++ b/internal/odoo/canary_dev_test.go
@@ -1,0 +1,76 @@
+//go:build devverify
+
+package odoo
+
+import (
+	"net/url"
+	"os"
+	"testing"
+)
+
+// TestDevVerify_LoginFlowCanary is the version-drift canary for the Odoo
+// web-login flow (#57). It exercises every web-controller assumption the
+// 2FA web session (clock in|out) encodes, against the DEV instance:
+//
+//  1. GET /web/login?db=<db> binds the session and serves a csrf_token input
+//  2. POST /web/login accepts csrf_token/login/password/redirect and answers
+//     with a 303 (to /web/login/totp when 2FA is pending)
+//  3. POST /web/login/totp accepts csrf_token/totp_token and answers 303
+//  4. the resulting session cookie authenticates JSON-RPC controller calls
+//
+// Run it via `mise run odoo:login-canary` — and always against dev BEFORE
+// any Odoo upgrade reaches test/prod. A failure names the encoded
+// assumption that broke.
+func TestDevVerify_LoginFlowCanary(t *testing.T) {
+	requireEnv := func(name string) string {
+		value := os.Getenv(name)
+		if value == "" {
+			// A canary must fail loudly, not skip: a silently skipped
+			// pre-upgrade check reads as a pass.
+			t.Fatalf("CANARY MISCONFIGURED: %s is not set — run `mise run prepare_env` first", name)
+		}
+		return value
+	}
+	baseURL := requireEnv("ODOO_URL")
+	database := requireEnv("ODOO_DATABASE")
+	login := requireEnv("ODOO_USERNAME")
+	webPassword := requireEnv("ODOO_WEB_PASSWORD")
+	totpSecret := os.Getenv("ODOO_TOTP_SECRET")
+
+	s := newJSONRPCSession(baseURL, database, login, webPassword, totpSecret)
+
+	// Assumption 1 in isolation, so a markup change is reported as such
+	// even before credentials come into play.
+	if _, err := s.fetchCSRFToken("/web/login?db=" + url.QueryEscape(database)); err != nil {
+		t.Fatalf("CANARY FAILED: %v", err)
+	}
+	t.Logf("PASS: GET /web/login?db=%s served a csrf_token input", database)
+
+	// Assumptions 2 and 3: full login including redirect semantics and,
+	// when 2FA is enabled, the TOTP challenge. Errors are self-diagnosing.
+	if err := s.authenticate(); err != nil {
+		t.Fatalf("CANARY FAILED: %v", err)
+	}
+	t.Log("PASS: POST /web/login accepted the credentials (303 redirect semantics intact)")
+
+	switch {
+	case totpSecret == "":
+		t.Error("CANARY INCOMPLETE: ODOO_TOTP_SECRET is not set, so the /web/login/totp leg was not exercised — enable 2FA on the dev user and set the secret")
+	case !s.totpCompleted:
+		t.Error("CANARY INCOMPLETE: ODOO_TOTP_SECRET is set but Odoo never redirected to /web/login/totp — 2FA seems disabled on the dev user, so the TOTP leg was not exercised")
+	default:
+		t.Log("PASS: POST /web/login/totp completed the 2FA challenge")
+	}
+
+	// Assumption 4: the session cookie authenticates controller calls.
+	// get_session_info is side-effect free (unlike the attendance toggle).
+	info, err := s.call("/web/session/get_session_info", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("CANARY FAILED: session-authenticated JSON-RPC call rejected — the login flow no longer yields a usable web session; check the Odoo version: %v", err)
+	}
+	uid, ok := info["uid"].(float64)
+	if !ok || uid <= 0 {
+		t.Fatalf("CANARY FAILED: /web/session/get_session_info returned no uid (%v) — the session is not authenticated; check the Odoo version", info["uid"])
+	}
+	t.Logf("PASS: session-authenticated call succeeded (uid=%d, db=%v)", int64(uid), info["db"])
+}

--- a/internal/odoo/jsonrpc.go
+++ b/internal/odoo/jsonrpc.go
@@ -29,6 +29,7 @@ type jsonRPCSession struct {
 	totpSecret    string
 	httpClient    *http.Client
 	authenticated bool
+	totpCompleted bool // a /web/login/totp challenge was served and passed
 	reqID         atomic.Int64
 }
 
@@ -88,9 +89,9 @@ func (s *jsonRPCSession) authenticate() error {
 		s.authenticated = true
 		return nil
 	case http.StatusOK:
-		return fmt.Errorf("authentication failed: Odoo rejected the login (the web session needs the login password, not the API key)")
+		return fmt.Errorf("authentication failed: Odoo re-rendered the login form (HTTP 200) — either the credentials were rejected (the web session needs the login password, not the API key), or the /web/login form fields (csrf_token, login, password, redirect) were renamed; check the Odoo version")
 	default:
-		return fmt.Errorf("authentication failed: unexpected status %d from /web/login", resp.StatusCode)
+		return fmt.Errorf("authentication failed: unexpected HTTP %d from POST /web/login — expected a 303 redirect (success, or /web/login/totp when 2FA is pending) or 200 (rejected); the login redirect semantics may have changed; check the Odoo version", resp.StatusCode)
 	}
 }
 
@@ -138,10 +139,11 @@ func (s *jsonRPCSession) completeTOTP() error {
 	// 200 means the form was re-rendered (wrong code).
 	if totpResp.StatusCode == http.StatusSeeOther || totpResp.StatusCode == http.StatusFound {
 		s.authenticated = true
+		s.totpCompleted = true
 		return nil
 	}
 
-	return fmt.Errorf("TOTP verification failed (status %d): check that totp_secret is correct", totpResp.StatusCode)
+	return fmt.Errorf("TOTP verification failed (HTTP %d) — either the code was rejected (check totp_secret and the system clock), or the /web/login/totp form fields (csrf_token, totp_token) were renamed; check the Odoo version", totpResp.StatusCode)
 }
 
 // csrfTokenRe matches the CSRF token hidden input in Odoo HTML forms.
@@ -162,7 +164,7 @@ func (s *jsonRPCSession) fetchCSRFToken(path string) (string, error) {
 
 	matches := csrfTokenRe.FindSubmatch(body)
 	if matches == nil {
-		return "", fmt.Errorf("CSRF token not found in %s response", path)
+		return "", fmt.Errorf("GET %s served no csrf_token input (HTTP %d, final URL %s) — the login page markup may have changed; check the Odoo version", path, resp.StatusCode, resp.Request.URL)
 	}
 	return string(matches[1]), nil
 }

--- a/internal/odoo/jsonrpc_test.go
+++ b/internal/odoo/jsonrpc_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 
@@ -33,6 +34,11 @@ type mockOdooServer struct {
 	login      string
 	password   string
 	callError  bool // make the attendance endpoint return a JSON-RPC error
+
+	// Version-drift simulation (#57): serve a login page without the
+	// csrf_token input, or answer POST /web/login with an unexpected status.
+	noCSRF          bool
+	loginPostStatus int
 
 	mu            sync.Mutex
 	dbBound       bool
@@ -87,11 +93,19 @@ func (m *mockOdooServer) handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "text/html")
+		if m.noCSRF {
+			_, _ = fmt.Fprint(w, `<form><input type="hidden" name="token" value="renamed"/></form>`)
+			return
+		}
 		_, _ = fmt.Fprintf(w, `<form><input type="hidden" name="csrf_token" value="%s"/></form>`, mockLoginCSRF)
 
 	case r.URL.Path == "/web/login" && r.Method == http.MethodPost:
 		if !m.dbBound {
 			http.NotFound(w, r)
+			return
+		}
+		if m.loginPostStatus != 0 {
+			w.WriteHeader(m.loginPostStatus)
 			return
 		}
 		_ = r.ParseForm()
@@ -258,12 +272,81 @@ func TestJSONRPCSession_Authenticate_WrongPassword(t *testing.T) {
 	})
 
 	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "wrong", "")
-	if err := s.authenticate(); err == nil {
+	err := s.authenticate()
+	if err == nil {
 		t.Fatal("expected error for wrong password, got nil")
 	}
 	if s.authenticated {
 		t.Error("expected authenticated = false")
 	}
+	// The 200 re-render is ambiguous: rejected credentials or renamed form
+	// fields (version drift). The message must name both (#57).
+	assertErrorContains(t, err,
+		"re-rendered the login form",
+		"login password, not the API key",
+		"csrf_token, login, password, redirect",
+		"check the Odoo version",
+	)
+}
+
+// assertErrorContains checks that the error message names each expected
+// fragment — the #57 requirement that failures point at the encoded
+// assumption that broke.
+func assertErrorContains(t *testing.T, err error, fragments ...string) {
+	t.Helper()
+	for _, want := range fragments {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing %q:\n%s", want, err.Error())
+		}
+	}
+}
+
+// TestJSONRPCSession_Diagnostic_MissingCSRFInput simulates Odoo 18/19
+// changing the login page markup so the csrf_token input disappears: the
+// error must name the missing input and point at version drift (#57).
+func TestJSONRPCSession_Diagnostic_MissingCSRFInput(t *testing.T) {
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:  true,
+		db:       "testdb",
+		login:    "user@test.com",
+		password: "pass",
+		noCSRF:   true,
+	})
+
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "pass", "")
+	err := s.authenticate()
+	if err == nil {
+		t.Fatal("expected error when login page has no csrf_token input, got nil")
+	}
+	assertErrorContains(t, err,
+		"no csrf_token input",
+		"login page markup may have changed",
+		"check the Odoo version",
+	)
+}
+
+// TestJSONRPCSession_Diagnostic_UnexpectedLoginStatus simulates the login
+// POST answering with a status outside the encoded 303/200 semantics: the
+// error must point at redirect-semantics drift (#57).
+func TestJSONRPCSession_Diagnostic_UnexpectedLoginStatus(t *testing.T) {
+	m := newMockOdooServer(t, &mockOdooServer{
+		multiDB:         true,
+		db:              "testdb",
+		login:           "user@test.com",
+		password:        "pass",
+		loginPostStatus: http.StatusTeapot,
+	})
+
+	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "pass", "")
+	err := s.authenticate()
+	if err == nil {
+		t.Fatal("expected error for unexpected login status, got nil")
+	}
+	assertErrorContains(t, err,
+		"unexpected HTTP 418 from POST /web/login",
+		"redirect semantics may have changed",
+		"check the Odoo version",
+	)
 }
 
 func TestJSONRPCSession_Authenticate_TOTPRequiredNoSecret(t *testing.T) {
@@ -296,12 +379,21 @@ func TestJSONRPCSession_Authenticate_TOTPWrongSecret(t *testing.T) {
 
 	// Client generates codes from a different secret than the server expects.
 	s := newJSONRPCSession(m.URL, "testdb", "user@test.com", "pass", "XYNHNRPRJMRNG6UP")
-	if err := s.authenticate(); err == nil {
+	err := s.authenticate()
+	if err == nil {
 		t.Fatal("expected TOTP verification error, got nil")
 	}
 	if m.authenticated {
 		t.Error("expected server session to remain unauthenticated")
 	}
+	// Like the login 200, a TOTP re-render is ambiguous: wrong code/clock
+	// skew or renamed form fields. The message must name both (#57).
+	assertErrorContains(t, err,
+		"TOTP verification failed",
+		"totp_secret and the system clock",
+		"csrf_token, totp_token",
+		"check the Odoo version",
+	)
 }
 
 func TestJSONRPCSession_Call(t *testing.T) {

--- a/mise.toml
+++ b/mise.toml
@@ -48,6 +48,11 @@ run = [
     "mise run odoo:ensure-test-user",
 ]
 
+[tasks."odoo:login-canary"]
+description = "Version-drift canary: exercise the full web-login flow (login + TOTP + session call) against dev — run BEFORE any Odoo upgrade reaches test/prod"
+# -count=1: a canary must never report a cached pass.
+run = "go test -tags devverify -count=1 -run TestDevVerify_LoginFlowCanary -v ./internal/odoo/"
+
 [tasks.test]
 description = "Run all tests"
 run = "go test ./..."

--- a/readme.md
+++ b/readme.md
@@ -501,6 +501,33 @@ The bootstrap therefore also provisions a permanent **non-admin** test user
   `clock status` and `entries` as the non-admin user and fails loudly on
   ACL faults. Run it after changes that touch Odoo model reads/writes.
 
+### Pre-upgrade check: web-login version-drift canary
+
+The 2FA web session used by `clock in|out` authenticates through Odoo's HTML
+login flow (`/web/login` → `/web/login/totp`) and therefore encodes
+web-controller internals that a new Odoo version may change
+([#57](https://github.com/seletz/odoo-work-cli/issues/57)):
+
+- `GET /web/login?db=<db>` binds the session and serves a `csrf_token` input
+- `POST /web/login` accepts `csrf_token`, `login`, `password`, `redirect`
+- 303 redirect = accepted (to `/web/login/totp` when 2FA is pending),
+  200 = rejected
+- `POST /web/login/totp` accepts `csrf_token`, `totp_token`
+
+```bash
+mise run odoo:login-canary
+```
+
+exercises the full flow against the **dev** instance — login, TOTP challenge,
+and a session-authenticated JSON-RPC call — and on failure names the encoded
+assumption that broke (e.g. "login page markup may have changed; check the
+Odoo version").
+
+**This is the mandatory pre-upgrade check.** Dev receives new Odoo versions
+first, so run the canary against dev **before any Odoo upgrade reaches test
+or prod**. If it fails, `clock in|out` (and `mise run odoo:create-api-key`,
+which mirrors the same flow) will break on that Odoo version.
+
 **Known limitation:** `clock in|out` currently fails against multi-database
 servers — the web session is not reliably bound to the requested database.
 Tracked in [#48](https://github.com/seletz/odoo-work-cli/issues/48).


### PR DESCRIPTION
Fixes #57

## What

The 2FA web session (`clock in|out`) authenticates through Odoo's HTML login flow and encodes web-controller internals that Odoo 18/19 may change. This PR makes that drift detectable before it bites:

- **`mise run odoo:login-canary`** — version-drift smoke test (`TestDevVerify_LoginFlowCanary`, `devverify` build tag, `-count=1` so a pass is never cached). Exercises the full flow against **dev**: `GET /web/login?db=` csrf scrape → `POST /web/login` 303 semantics → `POST /web/login/totp` challenge → a side-effect-free session-authenticated call (`/web/session/get_session_info`). Fails loudly and names the encoded assumption that broke; also fails (rather than silently passing) when the TOTP leg wasn't exercised or the env is missing.
- **Self-diagnosing runtime errors** — every auth error path in `internal/odoo/jsonrpc.go` now names the likely drift cause ("login page markup may have changed; check the Odoo version", form-field lists, redirect semantics). Unit-tested against a mock server simulating each drift case (missing csrf input, 200 re-render, unexpected status, TOTP rejection).
- **Docs** — readme section "Pre-upgrade check: web-login version-drift canary" documenting it as the mandatory check before any Odoo upgrade reaches test/prod (dev gets new versions first), referenced from CLAUDE.md's environment notes.

## Live verification against dev

Pass case:

```
=== RUN   TestDevVerify_LoginFlowCanary
    canary_dev_test.go:47: PASS: GET /web/login?db=odoo-work-cli served a csrf_token input
    canary_dev_test.go:54: PASS: POST /web/login accepted the credentials (303 redirect semantics intact)
    canary_dev_test.go:62: PASS: POST /web/login/totp completed the 2FA challenge
    canary_dev_test.go:75: PASS: session-authenticated call succeeded (uid=2, db=odoo-work-cli)
--- PASS: TestDevVerify_LoginFlowCanary (1.77s)
```

Forced failure (wrong `ODOO_TOTP_SECRET`):

```
=== RUN   TestDevVerify_LoginFlowCanary
    canary_dev_test.go:47: PASS: GET /web/login?db=odoo-work-cli served a csrf_token input
    canary_dev_test.go:52: CANARY FAILED: TOTP verification failed (HTTP 200) — either the code was rejected (check totp_secret and the system clock), or the /web/login/totp form fields (csrf_token, totp_token) were renamed; check the Odoo version
--- FAIL: TestDevVerify_LoginFlowCanary (1.49s)
```

## Checks

- `mise run test` green, `mise run lint` clean (also with `--build-tags devverify`), `mise run fmt` applied
- `mise.toml` change is a single new task block; no changes to `scripts/tasks/odoo/*` (kept tight for parallel work on #47/#55)