### PR TITLE
fix: provision a non-admin test user in the dev bootstrap (#55)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -45,6 +45,7 @@ run = [
     "mise run odoo:create-api-key",
     "mise run prepare_env",
     "mise run odoo:add-test-data",
+    "mise run odoo:ensure-test-user",
 ]
 
 [tasks.test]

--- a/readme.md
+++ b/readme.md
@@ -464,6 +464,8 @@ mise run odoo:create-api-key  # create an XML-RPC API key via the web login
 mise run odoo:add-test-data   # idempotent: seed the dev db with the modules,
                               # company, project, tasks and employee the
                               # checked-in config filters expect
+mise run odoo:ensure-test-user # idempotent: provision the non-admin test
+                              # user (see below)
 mise run odoo:prepare-db      # all of the above in order — bootstraps a
                               # freshly recreated dev db in one command
 ```
@@ -471,6 +473,33 @@ mise run odoo:prepare-db      # all of the above in order — bootstraps a
 When the dev database is recreated ("nuked"), all previously issued API keys
 are gone. `mise run odoo:prepare-db` fixes that end-to-end: it creates a new
 API key, refreshes `.env`, and re-seeds the test data.
+
+### Non-admin test user
+
+The CLI user provisioned above is an **administrator**, so ACL/permission
+bugs never surface with it — [#40](https://github.com/seletz/odoo-work-cli/issues/40)
+(`whoami` faulting for regular users) is exactly the class of bug that hides.
+The bootstrap therefore also provisions a permanent **non-admin** test user
+(issue [#55](https://github.com/seletz/odoo-work-cli/issues/55)):
+
+- `mise run odoo:ensure-test-user` — idempotent; creates/repairs a user with
+  login `test-user`, the regular-employee groups only (**Internal User**,
+  **Project/User**, **Timesheets/User: own timesheets only** — verified not
+  to be in Administration/Settings), and a linked `hr.employee` record.
+  Strictly Internal-User-only does not work: Odoo denies reading
+  `account.analytic.line` / `project.project` without the per-app user
+  groups every real employee has. A fresh random
+  password is set on every run and written to the `test-user-password` field
+  of the "ODOO Work CLI" 1Password item (printed once to stdout instead if
+  the `op` CLI is unavailable). The user has no 2FA, so XML-RPC accepts the
+  plain password — no API key needed.
+- `mise run odoo:run-as-user -- <args...>` — run any CLI/TUI command as that
+  user, e.g. `mise run odoo:run-as-user -- whoami`. Overrides
+  `ODOO_USERNAME`/`ODOO_PASSWORD`/`ODOO_WEB_PASSWORD` for the invocation
+  (password read from 1Password, or from `ODOO_TEST_USER_PASSWORD` if set).
+- `mise run odoo:smoke-test-user` — smoke check: runs `whoami`,
+  `clock status` and `entries` as the non-admin user and fails loudly on
+  ACL faults. Run it after changes that touch Odoo model reads/writes.
 
 **Known limitation:** `clock in|out` currently fails against multi-database
 servers — the web session is not reliably bound to the requested database.

--- a/scripts/tasks/odoo/ensure-test-user
+++ b/scripts/tasks/odoo/ensure-test-user
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+#MISE description="Idempotently provision the non-admin test user on the dev database (issue #55)"
+#USAGE flag "--login <login>" help="Login of the test user" default="test-user"
+#USAGE flag "--name <name>" help="Display name of the test user" default="Test User"
+#USAGE flag "--no-update-op" help="Only print the password; do not write it to the 1Password item"
+#USAGE flag "--op-item <item>" help="1Password item to update" default="ODOO Work CLI"
+#USAGE flag "--op-vault <vault>" help="1Password vault holding the item" default="Employee"
+
+"""Provision a permanent non-admin test user on the odoo-work-cli dev database.
+
+The dev bootstrap otherwise only knows the administrator CLI user, so
+ACL/permission bugs (like #40) stay invisible. This script idempotently
+ensures a regular user exists that mirrors what real employees have:
+
+* ``res.users`` with a deterministic login (default ``test-user``) and
+  the regular-employee groups only — **Internal User**, **Project/User**
+  and **Timesheets/User: own timesheets only** (the latter two are what
+  every real employee gets and are required by the server to read
+  ``project.project`` and ``account.analytic.line`` at all) — verified
+  to NOT be in Administration / Settings or Administration / Access Rights
+* a linked ``hr.employee`` record (required for timesheets/attendance)
+* a fresh random password, written to the 1Password item used by the
+  other dev tasks (field ``test-user-password``) so that
+  ``mise run odoo:run-as-user`` can pick it up; if the ``op`` CLI is not
+  available the password is printed once to stdout instead
+
+The password is rotated on every run — 1Password (or the printed value)
+is the source of truth. The user has no 2FA, so XML-RPC accepts the
+plain password directly (no API key needed).
+
+Required environment (see 1p.env / ``mise run prepare_env``):
+    ODOO_URL, ODOO_DATABASE, ODOO_USERNAME, ODOO_PASSWORD (admin API key)
+"""
+
+import os
+import secrets
+import shutil
+import ssl
+import subprocess
+import sys
+import xmlrpc.client
+
+
+def env(name):
+    value = os.environ.get(name, "")
+    if not value:
+        sys.exit(f"error: {name} is not set (run: mise run prepare_env)")
+    return value
+
+
+def ssl_context():
+    ctx = ssl.create_default_context()
+    if not ctx.get_ca_certs() and os.path.exists("/etc/ssl/cert.pem"):
+        ctx = ssl.create_default_context(cafile="/etc/ssl/cert.pem")
+    return ctx
+
+
+class OdooXMLRPC:
+    """Thin XML-RPC wrapper bound to one database and user."""
+
+    def __init__(self, url, database, username, api_key):
+        ctx = ssl_context()
+        self.database = database
+        self.api_key = api_key
+        common = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common", context=ctx)
+        self.uid = common.authenticate(database, username, api_key, {})
+        if not self.uid:
+            sys.exit("error: XML-RPC authentication failed (stale ODOO_PASSWORD api key? run: mise run odoo:create-api-key)")
+        self.models = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/object", context=ctx)
+
+    def call(self, model, method, *args, **kwargs):
+        return self.models.execute_kw(
+            self.database, self.uid, self.api_key, model, method, list(args), kwargs
+        )
+
+    def find(self, model, domain, fields=("id",)):
+        return self.call(model, "search_read", domain, fields=list(fields), limit=1)
+
+
+def step(message):
+    print(f"* {message}")
+
+
+def xmlid_res_id(odoo, module, name):
+    rec = odoo.find(
+        "ir.model.data", [["module", "=", module], ["name", "=", name]], ("res_id",)
+    )
+    if not rec:
+        sys.exit(f"error: xml id {module}.{name} not found on the server")
+    return rec[0]["res_id"]
+
+
+def main_company_id(odoo):
+    return odoo.call("res.company", "search", [], limit=1, order="id asc")[0]
+
+
+def ensure_user(odoo, login, name, group_ids, company_id):
+    user = odoo.find(
+        "res.users",
+        [["login", "=", login], ["active", "in", [True, False]]],
+        ("id", "active"),
+    )
+    values = {
+        "name": name,
+        "active": True,
+        "groups_id": [[6, 0, group_ids]],
+        "company_id": company_id,
+        "company_ids": [[6, 0, [company_id]]],
+    }
+    if user:
+        uid = user[0]["id"]
+        odoo.call("res.users", "write", [uid], values)
+        step(f"user '{login}': exists (id {uid}), groups reset to regular-employee set")
+    else:
+        values["login"] = login
+        uid = odoo.call("res.users", "create", values)
+        step(f"user '{login}': created (id {uid})")
+    return uid
+
+
+def verify_non_admin(odoo, uid, login):
+    forbidden = {
+        "Administration / Settings": xmlid_res_id(odoo, "base", "group_system"),
+        "Administration / Access Rights": xmlid_res_id(odoo, "base", "group_erp_manager"),
+    }
+    groups = odoo.call("res.users", "read", [uid], fields=["groups_id"])[0]["groups_id"]
+    for label, gid in forbidden.items():
+        if gid in groups:
+            sys.exit(f"error: user '{login}' is in {label} — refusing to continue")
+    step(f"user '{login}': verified NOT in Administration/Settings or Access Rights")
+
+
+def ensure_employee(odoo, uid, name, company_id):
+    employee = odoo.find("hr.employee", [["user_id", "=", uid]])
+    if employee:
+        step(f"employee for uid {uid}: exists (id {employee[0]['id']})")
+        return
+    eid = odoo.call(
+        "hr.employee",
+        "create",
+        {"name": name, "user_id": uid, "company_id": company_id},
+    )
+    step(f"employee for uid {uid}: created (id {eid})")
+
+
+def set_password(odoo, uid, login):
+    password = secrets.token_urlsafe(24)
+    odoo.call("res.users", "write", [uid], {"password": password})
+    step(f"user '{login}': password rotated")
+    return password
+
+
+def store_password(password, update_op, op_item, op_vault):
+    if update_op and shutil.which("op"):
+        cmd = ["op", "item", "edit", op_item, f"test-user-password[password]={password}", "--vault", op_vault]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            sys.exit(f"error: op item edit failed: {proc.stderr.strip()}")
+        step(f"password written to 1Password item '{op_item}' field test-user-password")
+        return
+    if update_op:
+        step("op CLI not available — printing the password once instead")
+    print(f"\ntest user password (store it now, it is not saved anywhere else):\n{password}")
+
+
+def main():
+    login = os.environ.get("usage_login", "test-user")
+    name = os.environ.get("usage_name", "Test User")
+    update_op = os.environ.get("usage_no_update_op", "false") != "true"
+    op_item = os.environ.get("usage_op_item", "ODOO Work CLI")
+    op_vault = os.environ.get("usage_op_vault", "Employee")
+
+    odoo = OdooXMLRPC(env("ODOO_URL"), env("ODOO_DATABASE"), env("ODOO_USERNAME"), env("ODOO_PASSWORD"))
+    print(f"connected to {os.environ['ODOO_URL']} db={odoo.database} uid={odoo.uid}\n")
+
+    # what every regular (non-admin) employee has: Internal User plus the
+    # default per-app user groups — without them the server denies reads
+    # on project.project / account.analytic.line outright
+    group_ids = [
+        xmlid_res_id(odoo, "base", "group_user"),
+        xmlid_res_id(odoo, "project", "group_project_user"),
+        xmlid_res_id(odoo, "hr_timesheet", "group_hr_timesheet_user"),
+    ]
+    company_id = main_company_id(odoo)
+    uid = ensure_user(odoo, login, name, group_ids, company_id)
+    verify_non_admin(odoo, uid, login)
+    ensure_employee(odoo, uid, name, company_id)
+    password = set_password(odoo, uid, login)
+    store_password(password, update_op, op_item, op_vault)
+
+    print(f"\nnon-admin test user '{login}' ready (uid {uid})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tasks/odoo/run-as-user
+++ b/scripts/tasks/odoo/run-as-user
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#MISE description="Build and run the CLI as the non-admin test user (pass args after --)"
+#MISE depends=["build"]
+
+# Runs any CLI/TUI command as the non-admin test user provisioned by
+# `mise run odoo:ensure-test-user` (issue #55). Overrides the Odoo
+# credentials for this invocation only — env vars take priority over the
+# [op_secrets] section in .odoo-work-cli.toml.
+#
+# The password comes from ODOO_TEST_USER_PASSWORD if set, otherwise it is
+# read from the 1Password item the bootstrap wrote it to. The test user has
+# no 2FA, so the plain password works for both XML-RPC and the web session.
+
+set -euo pipefail
+
+login="${ODOO_TEST_USER_LOGIN:-test-user}"
+password="${ODOO_TEST_USER_PASSWORD:-}"
+
+if [ -z "$password" ]; then
+    if command -v op >/dev/null 2>&1; then
+        password="$(op read "op://Employee/ODOO Work CLI/test-user-password")"
+    else
+        echo "error: ODOO_TEST_USER_PASSWORD is not set and the op CLI is not available" >&2
+        echo "hint: run 'mise run odoo:ensure-test-user' and export the printed password" >&2
+        exit 1
+    fi
+fi
+
+exec env \
+    ODOO_USERNAME="$login" \
+    ODOO_PASSWORD="$password" \
+    ODOO_WEB_PASSWORD="$password" \
+    ./odoo-work-cli "$@"

--- a/scripts/tasks/odoo/smoke-test-user
+++ b/scripts/tasks/odoo/smoke-test-user
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#MISE description="Smoke-check the non-admin test user against dev (whoami, clock status, entries)"
+
+# Runs a small set of read commands as the non-admin test user and fails
+# loudly if any of them faults (issue #55). This is exactly the class of
+# check that would have caught #40 (whoami faulting for regular users).
+
+set -euo pipefail
+
+commands=(
+    "whoami"
+    "clock status"
+    "entries"
+)
+
+for cmd in "${commands[@]}"; do
+    echo "==> odoo-work-cli ${cmd} (as non-admin test user)"
+    # shellcheck disable=SC2086
+    if ! mise run odoo:run-as-user -- ${cmd}; then
+        echo "FAIL: '${cmd}' failed as the non-admin test user (ACL regression?)" >&2
+        exit 1
+    fi
+    echo
+done
+
+echo "smoke check passed: all commands work as the non-admin test user"


### PR DESCRIPTION
Fixes #55

## What

The dev bootstrap only provisioned an **administrator** CLI user, so ACL/permission bugs (like #40, `whoami` faulting for regular users) stayed invisible during development. This adds three mise file tasks and wires the first into `odoo:prepare-db`:

- **`odoo:ensure-test-user`** — idempotently provisions a permanent non-admin user on dev: deterministic login `test-user`, the regular-employee groups only (Internal User, Project/User, Timesheets/User: own timesheets only), verified **not** in Administration/Settings or Administration/Access Rights, with a linked `hr.employee`. A fresh random password is rotated on every run and written to the `test-user-password` field of the "ODOO Work CLI" 1Password item (the `create-api-key` pattern); if `op` is unavailable it is printed once instead. No secrets in the repo.
- **`odoo:run-as-user -- <args...>`** — one-step way to run any CLI/TUI command as that user: overrides `ODOO_USERNAME`/`ODOO_PASSWORD`/`ODOO_WEB_PASSWORD` for the invocation (env vars beat `[op_secrets]`). The user has no 2FA, so XML-RPC accepts the plain password — no API key needed (the #40 verification proved this). Password comes from 1Password, or `ODOO_TEST_USER_PASSWORD` as fallback.
- **`odoo:smoke-test-user`** — runs `whoami`, `clock status`, `entries` as the non-admin user against dev and fails loudly on ACL faults.

The readme dev-environment section documents the flow.

## Deviation from the issue: not strictly "Internal User only"

Strictly Internal-User-only is not viable: Odoo 17 denies `account.analytic.line` reads outright without *Timesheets/User: own timesheets only* (or Analytic Accounting), and `project.project` needs *Project/User* — the smoke check's `entries` leg faulted with `Fault(4)` (transcript below caught it live). Those two per-app **user** groups are what every real employee gets from the default user template, so the test user models a regular employee — still zero admin groups, which the script verifies on every run.

## Verification transcript (against dev)

`ensure-test-user`, repair path (second run — first run created the user, id 9):

```
connected to https://odoo.intern.talos.k8s-dev.<redacted> db=odoo-work-cli uid=2

* user 'test-user': exists (id 9), groups reset to regular-employee set
* user 'test-user': verified NOT in Administration/Settings or Access Rights
* employee for uid 9: exists (id 5)
* user 'test-user': password rotated

non-admin test user 'test-user' ready (uid 9)
```

Smoke check, intermediate state (Internal User only) — fails loudly as designed:

```
==> odoo-work-cli entries (as non-admin test user)
Error: fetching timesheets: Fault(4): Sie haben keinen Zugriff auf Datensätze „Analytic Line" (account.analytic.line).
	- Project/Administrator
	- Technical/Analytic Accounting
	- Timesheets/User: own timesheets only
FAIL: 'entries' failed as the non-admin test user (ACL regression?)
```

Smoke check, final state — green:

```
==> odoo-work-cli whoami (as non-admin test user)
ID:      9
Name:    Test User
Login:   test-user
Company: digitalgedacht GmbH

==> odoo-work-cli clock status (as non-admin test user)
Status: Not clocked in
No attendance records today.

==> odoo-work-cli entries (as non-admin test user)
Week: 2026-07-13 to 2026-07-19
Total:  (0 entries)

smoke check passed: all commands work as the non-admin test user
```

`mise run test` green, `mise run lint` 0 issues (no Go changes).

## Note

The `op` CLI was not signed in during verification, so the 1Password write path (`op item edit`, same pattern as `create-api-key`) is untested live — the password-print fallback was used with `ODOO_TEST_USER_PASSWORD`. After merging, run `mise run odoo:ensure-test-user` once with `op` signed in to store the password; `odoo:run-as-user` then works with no extra env.
