### PR TITLE
feat(clock): allow backdated clock in/out and attendance editing

### DIFF
--- a/cmd/clock/clock.go
+++ b/cmd/clock/clock.go
@@ -14,6 +14,7 @@ func CMD(deps *app.Deps) *cobra.Command {
 	cmd.AddCommand(inCMD(deps))
 	cmd.AddCommand(outCMD(deps))
 	cmd.AddCommand(statusCMD(deps))
+	cmd.AddCommand(editCMD(deps))
 
 	return cmd
 }

--- a/cmd/clock/edit.go
+++ b/cmd/clock/edit.go
@@ -1,0 +1,185 @@
+package clock
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/seletz/odoo-work-cli/internal/app"
+	"github.com/seletz/odoo-work-cli/internal/odoo"
+	"github.com/seletz/odoo-work-cli/internal/parsing"
+	"github.com/seletz/odoo-work-cli/internal/tui"
+	"github.com/spf13/cobra"
+)
+
+// futureGrace tolerates small clock skew when rejecting future times.
+const futureGrace = time.Minute
+
+// parseAtFlag resolves an --at flag value ("HH:MM" or "YYYY-MM-DD HH:MM")
+// against now's day and rejects times in the future.
+func parseAtFlag(at string, now time.Time) (time.Time, error) {
+	day, err := parsing.ParseDay("", now)
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, err := parsing.ParseClockTime(at, day)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if t.After(now.Add(futureGrace)) {
+		return time.Time{}, fmt.Errorf("time %s is in the future", t.Format("2006-01-02 15:04"))
+	}
+	return t, nil
+}
+
+// editTimes holds the resolved clock edit target day and new times.
+type editTimes struct {
+	day      time.Time
+	checkIn  *time.Time
+	checkOut *time.Time
+}
+
+// resolveEditTimes parses and validates the clock edit flags against now.
+func resolveEditTimes(dateStr, inStr, outStr string, now time.Time) (*editTimes, error) {
+	if inStr == "" && outStr == "" {
+		return nil, errors.New("nothing to change: provide --in and/or --out")
+	}
+
+	day, err := parsing.ParseDay(dateStr, now)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &editTimes{day: day}
+	parse := func(s string) (*time.Time, error) {
+		if s == "" {
+			return nil, nil
+		}
+		t, err := parsing.ParseClockTime(s, day)
+		if err != nil {
+			return nil, err
+		}
+		if t.After(now.Add(futureGrace)) {
+			return nil, fmt.Errorf("time %s is in the future", t.Format("2006-01-02 15:04"))
+		}
+		return &t, nil
+	}
+
+	if result.checkIn, err = parse(inStr); err != nil {
+		return nil, err
+	}
+	if result.checkOut, err = parse(outStr); err != nil {
+		return nil, err
+	}
+	if result.checkIn != nil && result.checkOut != nil && !result.checkOut.After(*result.checkIn) {
+		return nil, fmt.Errorf("check-out %s is not after check-in %s",
+			result.checkOut.Format("15:04"), result.checkIn.Format("15:04"))
+	}
+	return result, nil
+}
+
+// pickEditTarget selects the attendance record to edit from the day's
+// records. Returns nil (without error) when there are no records; requires
+// an explicit ID when the day has more than one record.
+func pickEditTarget(records []odoo.AttendanceRecord, id int64) (*odoo.AttendanceRecord, error) {
+	if id > 0 {
+		for i := range records {
+			if records[i].ID == id {
+				return &records[i], nil
+			}
+		}
+		return nil, fmt.Errorf("no attendance record with ID %d on that date", id)
+	}
+
+	switch len(records) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &records[0], nil
+	default:
+		var lines []string
+		for _, r := range records {
+			lines = append(lines, "  "+formatRecord(&r))
+		}
+		return nil, fmt.Errorf("multiple attendance records on that date, select one with --id:\n%s",
+			strings.Join(lines, "\n"))
+	}
+}
+
+// formatRecord renders an attendance record for terminal output.
+func formatRecord(rec *odoo.AttendanceRecord) string {
+	checkIn := rec.CheckIn.Local().Format("2006-01-02 15:04")
+	if rec.CheckOut == nil {
+		return fmt.Sprintf("#%d %s - --:-- (running)", rec.ID, checkIn)
+	}
+	return fmt.Sprintf("#%d %s - %s (%s)", rec.ID, checkIn,
+		rec.CheckOut.Local().Format("15:04"), tui.FormatHours(rec.WorkedHours))
+}
+
+func editCMD(deps *app.Deps) *cobra.Command {
+	var dateStr, inStr, outStr string
+	var id int64
+
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit an attendance record's check-in/check-out time",
+		Long: `Edit the check-in and/or check-out time of an attendance record.
+
+By default the record of the given day (--date, default today) is edited.
+If the day has several records, select one with --id. If the day has no
+record yet, one is created when both --in and --out are given.
+
+Editing attendance over the API requires the 'Attendance Officer' access
+right, with you set as your own attendance manager.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req, err := resolveEditTimes(dateStr, inStr, outStr, time.Now())
+			if err != nil {
+				return err
+			}
+
+			client, err := deps.RequireClient()
+			if err != nil {
+				return err
+			}
+
+			records, err := client.ListAttendance(req.day.UTC(), req.day.AddDate(0, 0, 1).UTC())
+			if err != nil {
+				return err
+			}
+
+			target, err := pickEditTarget(records, id)
+			if err != nil {
+				return err
+			}
+
+			if target == nil {
+				if req.checkIn == nil || req.checkOut == nil {
+					return fmt.Errorf("no attendance record on %s: provide both --in and --out to create one",
+						req.day.Format("2006-01-02"))
+				}
+				newID, err := client.CreateAttendance(*req.checkIn, *req.checkOut)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Created attendance #%d: %s - %s\n", newID,
+					req.checkIn.Format("2006-01-02 15:04"), req.checkOut.Format("15:04"))
+				return nil
+			}
+
+			rec, err := client.EditAttendance(target.ID, req.checkIn, req.checkOut)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Updated attendance %s\n", formatRecord(rec))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&dateStr, "date", "", "day of the record to edit (YYYY-MM-DD, default today)")
+	cmd.Flags().StringVar(&inStr, "in", "", "new check-in time (HH:MM or YYYY-MM-DD HH:MM)")
+	cmd.Flags().StringVar(&outStr, "out", "", "new check-out time (HH:MM or YYYY-MM-DD HH:MM)")
+	cmd.Flags().Int64Var(&id, "id", 0, "attendance record ID (required if the day has several records)")
+
+	return cmd
+}

--- a/cmd/clock/edit_test.go
+++ b/cmd/clock/edit_test.go
@@ -1,0 +1,230 @@
+package clock
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/seletz/odoo-work-cli/internal/odoo"
+)
+
+var testZone = time.FixedZone("CEST", 2*3600)
+
+func TestParseAtFlag(t *testing.T) {
+	now := time.Date(2026, 7, 16, 14, 0, 0, 0, testZone)
+
+	tests := []struct {
+		name    string
+		at      string
+		want    time.Time
+		wantErr string
+	}{
+		{
+			name: "time today",
+			at:   "08:30",
+			want: time.Date(2026, 7, 16, 8, 30, 0, 0, testZone),
+		},
+		{
+			name: "explicit past date",
+			at:   "2026-07-15 17:15",
+			want: time.Date(2026, 7, 15, 17, 15, 0, 0, testZone),
+		},
+		{
+			name:    "future time rejected",
+			at:      "18:00",
+			wantErr: "in the future",
+		},
+		{
+			name:    "invalid format",
+			at:      "later",
+			wantErr: "invalid time",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAtFlag(tt.at, now)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveEditTimes(t *testing.T) {
+	now := time.Date(2026, 7, 16, 14, 0, 0, 0, testZone)
+
+	tests := []struct {
+		name    string
+		date    string
+		in      string
+		out     string
+		wantIn  *time.Time
+		wantOut *time.Time
+		wantDay time.Time
+		wantErr string
+	}{
+		{
+			name:    "check-in only, today",
+			in:      "08:30",
+			wantIn:  timePtr(time.Date(2026, 7, 16, 8, 30, 0, 0, testZone)),
+			wantDay: time.Date(2026, 7, 16, 0, 0, 0, 0, testZone),
+		},
+		{
+			name:    "both times on explicit date",
+			date:    "2026-07-14",
+			in:      "08:00",
+			out:     "16:30",
+			wantIn:  timePtr(time.Date(2026, 7, 14, 8, 0, 0, 0, testZone)),
+			wantOut: timePtr(time.Date(2026, 7, 14, 16, 30, 0, 0, testZone)),
+			wantDay: time.Date(2026, 7, 14, 0, 0, 0, 0, testZone),
+		},
+		{
+			name:    "check-out only",
+			out:     "12:15",
+			wantOut: timePtr(time.Date(2026, 7, 16, 12, 15, 0, 0, testZone)),
+			wantDay: time.Date(2026, 7, 16, 0, 0, 0, 0, testZone),
+		},
+		{
+			name:    "neither time given",
+			wantErr: "provide --in and/or --out",
+		},
+		{
+			name:    "future check-in rejected",
+			in:      "18:00",
+			wantErr: "in the future",
+		},
+		{
+			name:    "check-out before check-in",
+			in:      "12:00",
+			out:     "08:00",
+			wantErr: "not after check-in",
+		},
+		{
+			name:    "invalid date",
+			date:    "14.07.2026",
+			in:      "08:00",
+			wantErr: "invalid date",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveEditTimes(tt.date, tt.in, tt.out, now)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.day.Equal(tt.wantDay) {
+				t.Errorf("day = %v, want %v", got.day, tt.wantDay)
+			}
+			if !equalTimePtr(got.checkIn, tt.wantIn) {
+				t.Errorf("checkIn = %v, want %v", got.checkIn, tt.wantIn)
+			}
+			if !equalTimePtr(got.checkOut, tt.wantOut) {
+				t.Errorf("checkOut = %v, want %v", got.checkOut, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestPickEditTarget(t *testing.T) {
+	rec1 := odoo.AttendanceRecord{ID: 10, CheckIn: time.Date(2026, 7, 16, 6, 0, 0, 0, time.UTC)}
+	rec2 := odoo.AttendanceRecord{ID: 11, CheckIn: time.Date(2026, 7, 16, 11, 0, 0, 0, time.UTC)}
+
+	tests := []struct {
+		name    string
+		records []odoo.AttendanceRecord
+		id      int64
+		wantID  int64
+		wantNil bool
+		wantErr string
+	}{
+		{
+			name:    "no records yields nil without error",
+			records: nil,
+			wantNil: true,
+		},
+		{
+			name:    "single record selected",
+			records: []odoo.AttendanceRecord{rec1},
+			wantID:  10,
+		},
+		{
+			name:    "multiple records require --id",
+			records: []odoo.AttendanceRecord{rec1, rec2},
+			wantErr: "--id",
+		},
+		{
+			name:    "explicit id selects among multiple",
+			records: []odoo.AttendanceRecord{rec1, rec2},
+			id:      11,
+			wantID:  11,
+		},
+		{
+			name:    "explicit id not found",
+			records: []odoo.AttendanceRecord{rec1},
+			id:      99,
+			wantErr: "no attendance record with ID 99",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pickEditTarget(tt.records, tt.id)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil target, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected a target, got nil")
+			}
+			if got.ID != tt.wantID {
+				t.Errorf("ID = %d, want %d", got.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+func equalTimePtr(a, b *time.Time) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return a == nil || a.Equal(*b)
+}

--- a/cmd/clock/in.go
+++ b/cmd/clock/in.go
@@ -9,6 +9,8 @@ import (
 )
 
 func inCMD(deps *app.Deps) *cobra.Command {
+	var at string
+
 	InCmd := &cobra.Command{
 		Use:   "in",
 		Short: "Clock in (start attendance)",
@@ -16,6 +18,19 @@ func inCMD(deps *app.Deps) *cobra.Command {
 			client, err := deps.RequireClient()
 			if err != nil {
 				return err
+			}
+
+			if at != "" {
+				t, err := parseAtFlag(at, time.Now())
+				if err != nil {
+					return err
+				}
+				id, err := client.ClockInAt(t)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Clocked in at %s (#%d)\n", t.Format("2006-01-02 15:04"), id)
+				return nil
 			}
 
 			_, err = client.ClockIn()
@@ -27,6 +42,9 @@ func inCMD(deps *app.Deps) *cobra.Command {
 			return nil
 		},
 	}
+
+	InCmd.Flags().StringVar(&at, "at", "",
+		"clock in at a past time (HH:MM or YYYY-MM-DD HH:MM) instead of now; requires attendance officer rights")
 
 	return InCmd
 }

--- a/cmd/clock/out.go
+++ b/cmd/clock/out.go
@@ -10,6 +10,8 @@ import (
 )
 
 func outCMD(deps *app.Deps) *cobra.Command {
+	var at string
+
 	cmd := &cobra.Command{
 		Use:   "out",
 		Short: "Clock out (end attendance)",
@@ -17,6 +19,20 @@ func outCMD(deps *app.Deps) *cobra.Command {
 			client, err := deps.RequireClient()
 			if err != nil {
 				return err
+			}
+
+			if at != "" {
+				t, err := parseAtFlag(at, time.Now())
+				if err != nil {
+					return err
+				}
+				rec, err := client.ClockOutAt(t)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Clocked out at %s\n", t.Format("2006-01-02 15:04"))
+				fmt.Printf("Duration: %s (%.2fh)\n", tui.FormatHours(rec.WorkedHours), rec.WorkedHours)
+				return nil
 			}
 
 			rec, err := client.ClockOut()
@@ -29,5 +45,9 @@ func outCMD(deps *app.Deps) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&at, "at", "",
+		"clock out at a past time (HH:MM or YYYY-MM-DD HH:MM) instead of now; requires attendance officer rights")
+
 	return cmd
 }

--- a/internal/app/deps_test.go
+++ b/internal/app/deps_test.go
@@ -64,6 +64,22 @@ func (s *stubClient) ClockOut() (*odoo.AttendanceRecord, error) {
 	return nil, nil
 }
 
+func (s *stubClient) ClockInAt(time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (s *stubClient) ClockOutAt(time.Time) (*odoo.AttendanceRecord, error) {
+	return nil, nil
+}
+
+func (s *stubClient) CreateAttendance(time.Time, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (s *stubClient) EditAttendance(int64, *time.Time, *time.Time) (*odoo.AttendanceRecord, error) {
+	return nil, nil
+}
+
 func (s *stubClient) AttendanceStatus() (*odoo.AttendanceStatus, error) {
 	return nil, nil
 }

--- a/internal/odoo/attendance.go
+++ b/internal/odoo/attendance.go
@@ -139,6 +139,11 @@ func fetchAttendanceStatus(searchFn attendanceSearchFunc, empID int64, now time.
 // records that started before the range (check_out = false), so that
 // attendance spanning midnight is correctly included.
 func fetchAttendanceRange(searchFn attendanceSearchFunc, empID int64, from, to time.Time) ([]map[string]interface{}, error) {
+	// Odoo compares datetimes as UTC strings; normalize the bounds so that
+	// callers may pass local times.
+	from = from.UTC()
+	to = to.UTC()
+
 	opts := goOdoo.NewOptions().
 		FetchFields("id", "employee_id", "check_in", "check_out", "worked_hours")
 

--- a/internal/odoo/attendance_write.go
+++ b/internal/odoo/attendance_write.go
@@ -1,0 +1,170 @@
+package odoo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	goOdoo "github.com/skilld-labs/go-odoo"
+)
+
+// odooAccessErrorPrefix identifies Odoo AccessError faults (ACL / record-rule
+// violations, fault code 4) in error messages. The XML-RPC transport under
+// go-odoo flattens faults into net/rpc string errors of the form
+// "Fault(<code>): <message>", so the code is only available textually. The
+// message text is locale-dependent, the code is not.
+const odooAccessErrorPrefix = "Fault(4):"
+
+// attendanceAccessHint explains the ACL constraint on hr.attendance writes
+// discovered in #47: regular employees may only read their own records;
+// create/write/unlink require the officer group, and the officer record rule
+// additionally requires being the employee's attendance manager.
+const attendanceAccessHint = "editing attendance over the API requires the " +
+	"'Attendance Officer' access right with you set as your own attendance " +
+	"manager; ask your administrator, or use plain 'clock in'/'clock out'"
+
+// wrapAttendanceAccessErr wraps an hr.attendance write error, appending a
+// hint about the required access rights when Odoo raised an AccessError.
+func wrapAttendanceAccessErr(err error, action string) error {
+	if strings.HasPrefix(err.Error(), odooAccessErrorPrefix) {
+		return fmt.Errorf("%s: %w\nhint: %s", action, err, attendanceAccessHint)
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
+// createAttendance creates an hr.attendance record via XML-RPC.
+// checkOut may be nil for an open (still clocked in) record.
+func (x *XMLRPCClient) createAttendance(checkIn time.Time, checkOut *time.Time) (int64, error) {
+	empID, err := x.findEmployeeID()
+	if err != nil {
+		return 0, err
+	}
+
+	vals := map[string]interface{}{
+		"employee_id": empID,
+		"check_in":    checkIn.UTC().Format(odooDatetimeFormat),
+	}
+	if checkOut != nil {
+		vals["check_out"] = checkOut.UTC().Format(odooDatetimeFormat)
+	}
+
+	resp, err := x.client.ExecuteKw("create", "hr.attendance",
+		[]interface{}{vals}, goOdoo.NewOptions())
+	if err != nil {
+		return 0, wrapAttendanceAccessErr(err, "creating attendance record")
+	}
+
+	switch id := resp.(type) {
+	case int64:
+		return id, nil
+	case float64:
+		return int64(id), nil
+	default:
+		return 0, fmt.Errorf("unexpected create response type %T", resp)
+	}
+}
+
+// readAttendance fetches a single attendance record by ID.
+func (x *XMLRPCClient) readAttendance(id int64) (*AttendanceRecord, error) {
+	criteria := goOdoo.NewCriteria().Add("id", "=", id)
+	opts := goOdoo.NewOptions().
+		FetchFields("id", "employee_id", "check_in", "check_out", "worked_hours")
+	records, err := x.searchReadRaw("hr.attendance", criteria, opts)
+	if err != nil {
+		return nil, fmt.Errorf("reading attendance record: %w", err)
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("attendance record %d not found", id)
+	}
+	return parseAttendanceRecord(records[0])
+}
+
+// ClockInAt creates an attendance record with the given check-in time via
+// XML-RPC. Unlike ClockIn (which goes through the sudo'd systray controller
+// and always uses the server's now()), this requires attendance officer
+// rights. Returns an error if already clocked in.
+func (x *XMLRPCClient) ClockInAt(checkIn time.Time) (int64, error) {
+	status, err := x.AttendanceStatus()
+	if err != nil {
+		return 0, err
+	}
+	if status.ClockedIn {
+		return 0, errors.New("already clocked in")
+	}
+
+	return x.createAttendance(checkIn, nil)
+}
+
+// ClockOutAt writes the given check-out time on the open attendance record
+// via XML-RPC. Requires attendance officer rights. Returns the completed
+// record with computed worked_hours.
+func (x *XMLRPCClient) ClockOutAt(checkOut time.Time) (*AttendanceRecord, error) {
+	status, err := x.AttendanceStatus()
+	if err != nil {
+		return nil, err
+	}
+	if !status.ClockedIn {
+		return nil, errors.New("not clocked in")
+	}
+	if status.CheckIn != nil && !checkOut.After(*status.CheckIn) {
+		return nil, fmt.Errorf("check-out %s is not after check-in %s",
+			checkOut.Format("15:04"),
+			status.CheckIn.In(checkOut.Location()).Format("15:04"))
+	}
+
+	fields := map[string]interface{}{
+		"check_out": checkOut.UTC().Format(odooDatetimeFormat),
+	}
+	_, err = x.client.ExecuteKw("write", "hr.attendance",
+		[]interface{}{[]int64{status.CurrentID}, fields}, goOdoo.NewOptions())
+	if err != nil {
+		return nil, wrapAttendanceAccessErr(err, fmt.Sprintf("closing attendance record %d", status.CurrentID))
+	}
+
+	return x.readAttendance(status.CurrentID)
+}
+
+// CreateAttendance creates a closed attendance record with explicit check-in
+// and check-out times via XML-RPC. Requires attendance officer rights.
+func (x *XMLRPCClient) CreateAttendance(checkIn, checkOut time.Time) (int64, error) {
+	if !checkOut.After(checkIn) {
+		return 0, fmt.Errorf("check-out %s is not after check-in %s",
+			checkOut.Format("15:04"),
+			checkIn.Format("15:04"))
+	}
+	return x.createAttendance(checkIn, &checkOut)
+}
+
+// EditAttendance updates check_in and/or check_out on an attendance record
+// via XML-RPC; nil times are left unchanged. Requires attendance officer
+// rights. Returns the updated record.
+func (x *XMLRPCClient) EditAttendance(id int64, checkIn, checkOut *time.Time) (*AttendanceRecord, error) {
+	if id <= 0 {
+		return nil, errors.New("attendance ID is required")
+	}
+	if checkIn == nil && checkOut == nil {
+		return nil, errors.New("nothing to update: provide a new check-in and/or check-out time")
+	}
+	if checkIn != nil && checkOut != nil && !checkOut.After(*checkIn) {
+		return nil, fmt.Errorf("check-out %s is not after check-in %s",
+			checkOut.Format("15:04"),
+			checkIn.Format("15:04"))
+	}
+
+	fields := map[string]interface{}{}
+	if checkIn != nil {
+		fields["check_in"] = checkIn.UTC().Format(odooDatetimeFormat)
+	}
+	if checkOut != nil {
+		fields["check_out"] = checkOut.UTC().Format(odooDatetimeFormat)
+	}
+
+	_, err := x.client.ExecuteKw("write", "hr.attendance",
+		[]interface{}{[]int64{id}, fields}, goOdoo.NewOptions())
+	if err != nil {
+		return nil, wrapAttendanceAccessErr(err, fmt.Sprintf("updating attendance record %d", id))
+	}
+
+	return x.readAttendance(id)
+}

--- a/internal/odoo/attendance_write_test.go
+++ b/internal/odoo/attendance_write_test.go
@@ -1,0 +1,440 @@
+package odoo
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	goOdoo "github.com/skilld-labs/go-odoo"
+)
+
+const emptyArrayResponse = `<?xml version="1.0"?>
+<methodResponse><params><param><value><array><data></data></array></value></param></params></methodResponse>`
+
+const writeOKResponse = `<?xml version="1.0"?>
+<methodResponse><params><param><value><boolean>1</boolean></value></param></params></methodResponse>`
+
+// employeeResponse answers the findEmployeeID search_read.
+const employeeResponse = `<?xml version="1.0"?>
+<methodResponse><params><param><value><array><data>
+<value><struct>
+<member><name>id</name><value><int>7</int></value></member>
+</struct></value>
+</data></array></value></param></params></methodResponse>`
+
+func intResponse(id int64) string {
+	return fmt.Sprintf(`<?xml version="1.0"?>
+<methodResponse><params><param><value><int>%d</int></value></param></params></methodResponse>`, id)
+}
+
+// attRecordResponse builds a single-record hr.attendance search_read response.
+// checkOut == "" renders as false (open record).
+func attRecordResponse(id int64, checkIn, checkOut string, workedHours float64) string {
+	out := "<boolean>0</boolean>"
+	if checkOut != "" {
+		out = fmt.Sprintf("<string>%s</string>", checkOut)
+	}
+	return fmt.Sprintf(`<?xml version="1.0"?>
+<methodResponse><params><param><value><array><data>
+<value><struct>
+<member><name>id</name><value><int>%d</int></value></member>
+<member><name>employee_id</name><value><array><data>
+<value><int>7</int></value><value><string>Test User</string></value>
+</data></array></value></member>
+<member><name>check_in</name><value><string>%s</string></value></member>
+<member><name>check_out</name><value>%s</value></member>
+<member><name>worked_hours</name><value><double>%f</double></value></member>
+</struct></value>
+</data></array></value></param></params></methodResponse>`, id, checkIn, out, workedHours)
+}
+
+// attendanceWriteMock simulates the Odoo XML-RPC endpoint for attendance
+// write flows. hr.attendance search_read responses are consumed from
+// attSearch in request order; create/write bodies are captured.
+type attendanceWriteMock struct {
+	t          *testing.T
+	attSearch  []string
+	createResp string
+	writeResp  string
+
+	createBody string
+	writeBody  string
+}
+
+func (m *attendanceWriteMock) server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			m.t.Errorf("reading request body: %v", err)
+		}
+		body := string(raw)
+		w.Header().Set("Content-Type", "text/xml")
+
+		switch r.URL.Path {
+		case "/xmlrpc/2/common":
+			_, _ = fmt.Fprint(w, authenticateResponse)
+		case "/xmlrpc/2/object":
+			switch {
+			case strings.Contains(body, "<string>hr.employee</string>"):
+				_, _ = fmt.Fprint(w, employeeResponse)
+			case strings.Contains(body, "<string>hr.attendance</string>"):
+				switch {
+				case strings.Contains(body, "<string>create</string>"):
+					m.createBody = body
+					if m.createResp == "" {
+						m.t.Error("unexpected hr.attendance create call")
+						_, _ = fmt.Fprint(w, aclFaultResponse)
+						return
+					}
+					_, _ = fmt.Fprint(w, m.createResp)
+				case strings.Contains(body, "<string>write</string>"):
+					m.writeBody = body
+					if m.writeResp == "" {
+						m.t.Error("unexpected hr.attendance write call")
+						_, _ = fmt.Fprint(w, aclFaultResponse)
+						return
+					}
+					_, _ = fmt.Fprint(w, m.writeResp)
+				case strings.Contains(body, "<string>search_read</string>"):
+					if len(m.attSearch) == 0 {
+						m.t.Error("unexpected hr.attendance search_read call")
+						_, _ = fmt.Fprint(w, emptyArrayResponse)
+						return
+					}
+					resp := m.attSearch[0]
+					m.attSearch = m.attSearch[1:]
+					_, _ = fmt.Fprint(w, resp)
+				default:
+					m.t.Errorf("unexpected hr.attendance method in body: %s", body)
+					http.NotFound(w, r)
+				}
+			default:
+				m.t.Errorf("unexpected model in body: %s", body)
+				http.NotFound(w, r)
+			}
+		default:
+			m.t.Errorf("unexpected request path %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func (m *attendanceWriteMock) client(t *testing.T) *XMLRPCClient {
+	t.Helper()
+	server := m.server()
+	t.Cleanup(server.Close)
+	client, err := NewXMLRPCClient(server.URL, "testdb", "test@example.com", "api-key", "", "", nil)
+	if err != nil {
+		t.Fatalf("creating client: %v", err)
+	}
+	t.Cleanup(client.Close)
+	return client
+}
+
+var testZone = time.FixedZone("CEST", 2*3600)
+
+func TestClockInAt_CreatesBackdatedRecord(t *testing.T) {
+	mock := &attendanceWriteMock{
+		t: t,
+		// status queries: today range + open records, both empty
+		attSearch:  []string{emptyArrayResponse, emptyArrayResponse},
+		createResp: intResponse(43),
+	}
+	client := mock.client(t)
+
+	// 08:30 local CEST == 06:30 UTC
+	id, err := client.ClockInAt(time.Date(2026, 7, 16, 8, 30, 0, 0, testZone))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 43 {
+		t.Errorf("ID = %d, want 43", id)
+	}
+	if !strings.Contains(mock.createBody, "<string>2026-07-16 06:30:00</string>") {
+		t.Errorf("create body missing UTC check_in, got: %s", mock.createBody)
+	}
+	if !strings.Contains(mock.createBody, "<name>employee_id</name>") {
+		t.Errorf("create body missing employee_id, got: %s", mock.createBody)
+	}
+	if strings.Contains(mock.createBody, "<name>check_out</name>") {
+		t.Errorf("create body must not set check_out, got: %s", mock.createBody)
+	}
+}
+
+func TestClockInAt_AlreadyClockedIn(t *testing.T) {
+	open := attRecordResponse(50, "2026-07-16 05:00:00", "", 0)
+	mock := &attendanceWriteMock{
+		t:         t,
+		attSearch: []string{emptyArrayResponse, open},
+	}
+	client := mock.client(t)
+
+	_, err := client.ClockInAt(time.Date(2026, 7, 16, 8, 30, 0, 0, testZone))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "already clocked in" {
+		t.Errorf("error = %q, want %q", err.Error(), "already clocked in")
+	}
+}
+
+func TestClockInAt_AccessDenied(t *testing.T) {
+	mock := &attendanceWriteMock{
+		t:          t,
+		attSearch:  []string{emptyArrayResponse, emptyArrayResponse},
+		createResp: aclFaultResponse,
+	}
+	client := mock.client(t)
+
+	_, err := client.ClockInAt(time.Date(2026, 7, 16, 8, 30, 0, 0, testZone))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Attendance Officer") {
+		t.Errorf("error should hint at officer rights, got: %v", err)
+	}
+}
+
+func TestClockOutAt_ClosesOpenRecord(t *testing.T) {
+	open := attRecordResponse(50, "2026-07-16 06:00:00", "", 0)
+	closed := attRecordResponse(50, "2026-07-16 06:00:00", "2026-07-16 10:30:00", 4.5)
+	mock := &attendanceWriteMock{
+		t:         t,
+		attSearch: []string{emptyArrayResponse, open, closed},
+		writeResp: writeOKResponse,
+	}
+	client := mock.client(t)
+
+	// 12:30 local CEST == 10:30 UTC
+	rec, err := client.ClockOutAt(time.Date(2026, 7, 16, 12, 30, 0, 0, testZone))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.ID != 50 {
+		t.Errorf("ID = %d, want 50", rec.ID)
+	}
+	if rec.WorkedHours != 4.5 {
+		t.Errorf("WorkedHours = %f, want 4.5", rec.WorkedHours)
+	}
+	if !strings.Contains(mock.writeBody, "<string>2026-07-16 10:30:00</string>") {
+		t.Errorf("write body missing UTC check_out, got: %s", mock.writeBody)
+	}
+}
+
+func TestClockOutAt_NotClockedIn(t *testing.T) {
+	mock := &attendanceWriteMock{
+		t:         t,
+		attSearch: []string{emptyArrayResponse, emptyArrayResponse},
+	}
+	client := mock.client(t)
+
+	_, err := client.ClockOutAt(time.Date(2026, 7, 16, 12, 30, 0, 0, testZone))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "not clocked in" {
+		t.Errorf("error = %q, want %q", err.Error(), "not clocked in")
+	}
+}
+
+func TestClockOutAt_BeforeCheckIn(t *testing.T) {
+	// open record check_in 09:00 UTC == 11:00 CEST; clock out at 10:00 CEST
+	open := attRecordResponse(50, "2026-07-16 09:00:00", "", 0)
+	mock := &attendanceWriteMock{
+		t:         t,
+		attSearch: []string{emptyArrayResponse, open},
+	}
+	client := mock.client(t)
+
+	_, err := client.ClockOutAt(time.Date(2026, 7, 16, 10, 0, 0, 0, testZone))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not after check-in") {
+		t.Errorf("error = %q, want it to mention 'not after check-in'", err.Error())
+	}
+}
+
+func TestCreateAttendance_SetsBothTimes(t *testing.T) {
+	mock := &attendanceWriteMock{
+		t:          t,
+		createResp: intResponse(44),
+	}
+	client := mock.client(t)
+
+	id, err := client.CreateAttendance(
+		time.Date(2026, 7, 15, 8, 0, 0, 0, testZone),
+		time.Date(2026, 7, 15, 16, 0, 0, 0, testZone))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 44 {
+		t.Errorf("ID = %d, want 44", id)
+	}
+	if !strings.Contains(mock.createBody, "<string>2026-07-15 06:00:00</string>") {
+		t.Errorf("create body missing UTC check_in, got: %s", mock.createBody)
+	}
+	if !strings.Contains(mock.createBody, "<string>2026-07-15 14:00:00</string>") {
+		t.Errorf("create body missing UTC check_out, got: %s", mock.createBody)
+	}
+}
+
+func TestCreateAttendance_CheckOutNotAfterCheckIn(t *testing.T) {
+	mock := &attendanceWriteMock{t: t}
+	client := mock.client(t)
+
+	_, err := client.CreateAttendance(
+		time.Date(2026, 7, 15, 16, 0, 0, 0, testZone),
+		time.Date(2026, 7, 15, 8, 0, 0, 0, testZone))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not after check-in") {
+		t.Errorf("error = %q, want it to mention 'not after check-in'", err.Error())
+	}
+}
+
+func TestEditAttendance_UpdatesCheckInOnly(t *testing.T) {
+	updated := attRecordResponse(50, "2026-07-16 06:00:00", "2026-07-16 14:00:00", 8.0)
+	mock := &attendanceWriteMock{
+		t:         t,
+		attSearch: []string{updated},
+		writeResp: writeOKResponse,
+	}
+	client := mock.client(t)
+
+	checkIn := time.Date(2026, 7, 16, 8, 0, 0, 0, testZone) // 06:00 UTC
+	rec, err := client.EditAttendance(50, &checkIn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.ID != 50 {
+		t.Errorf("ID = %d, want 50", rec.ID)
+	}
+	if rec.WorkedHours != 8.0 {
+		t.Errorf("WorkedHours = %f, want 8.0", rec.WorkedHours)
+	}
+	if !strings.Contains(mock.writeBody, "<name>check_in</name>") {
+		t.Errorf("write body missing check_in, got: %s", mock.writeBody)
+	}
+	if !strings.Contains(mock.writeBody, "<string>2026-07-16 06:00:00</string>") {
+		t.Errorf("write body missing UTC check_in value, got: %s", mock.writeBody)
+	}
+	if strings.Contains(mock.writeBody, "<name>check_out</name>") {
+		t.Errorf("write body must not set check_out, got: %s", mock.writeBody)
+	}
+}
+
+func TestEditAttendance_UpdatesBothTimes(t *testing.T) {
+	updated := attRecordResponse(50, "2026-07-16 06:00:00", "2026-07-16 14:00:00", 8.0)
+	mock := &attendanceWriteMock{
+		t:         t,
+		attSearch: []string{updated},
+		writeResp: writeOKResponse,
+	}
+	client := mock.client(t)
+
+	checkIn := time.Date(2026, 7, 16, 8, 0, 0, 0, testZone)
+	checkOut := time.Date(2026, 7, 16, 16, 0, 0, 0, testZone)
+	rec, err := client.EditAttendance(50, &checkIn, &checkOut)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.CheckOut == nil {
+		t.Fatal("expected CheckOut to be set")
+	}
+	if !strings.Contains(mock.writeBody, "<name>check_out</name>") {
+		t.Errorf("write body missing check_out, got: %s", mock.writeBody)
+	}
+}
+
+func TestEditAttendance_Validation(t *testing.T) {
+	checkIn := time.Date(2026, 7, 16, 16, 0, 0, 0, testZone)
+	checkOut := time.Date(2026, 7, 16, 8, 0, 0, 0, testZone)
+
+	tests := []struct {
+		name     string
+		id       int64
+		checkIn  *time.Time
+		checkOut *time.Time
+		wantMsg  string
+	}{
+		{
+			name:    "no fields to update",
+			id:      50,
+			wantMsg: "nothing to update: provide a new check-in and/or check-out time",
+		},
+		{
+			name:    "invalid id",
+			id:      0,
+			checkIn: &checkIn,
+			wantMsg: "attendance ID is required",
+		},
+		{
+			name:     "check-out not after check-in",
+			id:       50,
+			checkIn:  &checkIn,
+			checkOut: &checkOut,
+			wantMsg:  "check-out 08:00 is not after check-in 16:00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &attendanceWriteMock{t: t}
+			client := mock.client(t)
+
+			_, err := client.EditAttendance(tt.id, tt.checkIn, tt.checkOut)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() != tt.wantMsg {
+				t.Errorf("error = %q, want %q", err.Error(), tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestEditAttendance_AccessDenied(t *testing.T) {
+	mock := &attendanceWriteMock{
+		t:         t,
+		writeResp: aclFaultResponse,
+	}
+	client := mock.client(t)
+
+	checkIn := time.Date(2026, 7, 16, 8, 0, 0, 0, testZone)
+	_, err := client.EditAttendance(50, &checkIn, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Attendance Officer") {
+		t.Errorf("error should hint at officer rights, got: %v", err)
+	}
+}
+
+func TestFetchAttendanceRange_ConvertsBoundsToUTC(t *testing.T) {
+	var captured []string
+	searchFn := func(_ string, criteria *goOdoo.Criteria, _ *goOdoo.Options) ([]map[string]interface{}, error) {
+		captured = append(captured, fmt.Sprintf("%v", *criteria))
+		return nil, nil
+	}
+
+	// local midnight CEST == 22:00 UTC the previous day
+	from := time.Date(2026, 7, 16, 0, 0, 0, 0, testZone)
+	to := from.AddDate(0, 0, 1)
+	if _, err := fetchAttendanceRange(searchFn, 7, from, to); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	all := strings.Join(captured, " | ")
+	if !strings.Contains(all, "2026-07-15 22:00:00") {
+		t.Errorf("criteria should contain UTC-converted from bound, got: %s", all)
+	}
+	if strings.Contains(all, "2026-07-16 00:00:00") {
+		t.Errorf("criteria must not contain local wall-clock bound, got: %s", all)
+	}
+}

--- a/internal/odoo/client.go
+++ b/internal/odoo/client.go
@@ -123,6 +123,19 @@ type Client interface {
 	ClockIn() (int64, error)
 	// ClockOut writes check_out = now on the open attendance record.
 	ClockOut() (*AttendanceRecord, error)
+	// ClockInAt creates an attendance record with an explicit check-in time
+	// via XML-RPC. Requires attendance officer rights.
+	ClockInAt(checkIn time.Time) (int64, error)
+	// ClockOutAt closes the open attendance record at an explicit time via
+	// XML-RPC. Requires attendance officer rights.
+	ClockOutAt(checkOut time.Time) (*AttendanceRecord, error)
+	// CreateAttendance creates a closed attendance record with explicit
+	// check-in and check-out times. Requires attendance officer rights.
+	CreateAttendance(checkIn, checkOut time.Time) (int64, error)
+	// EditAttendance updates check_in and/or check_out on an attendance
+	// record; nil times are left unchanged. Returns the updated record.
+	// Requires attendance officer rights.
+	EditAttendance(id int64, checkIn, checkOut *time.Time) (*AttendanceRecord, error)
 	// AttendanceStatus returns the current clock state and today's periods.
 	AttendanceStatus() (*AttendanceStatus, error)
 	// ListAttendance returns attendance records with check_in in [from, to),

--- a/internal/odoo/whoami_test.go
+++ b/internal/odoo/whoami_test.go
@@ -27,6 +27,10 @@ type mockClient struct {
 	clockInErr        error
 	clockOutRecord    *AttendanceRecord
 	clockOutErr       error
+	createAttID       int64
+	createAttErr      error
+	editAttRecord     *AttendanceRecord
+	editAttErr        error
 	attendanceStatus  *AttendanceStatus
 	attendanceErr     error
 	attendanceRecords []AttendanceRecord
@@ -85,6 +89,22 @@ func (m *mockClient) ClockIn() (int64, error) {
 
 func (m *mockClient) ClockOut() (*AttendanceRecord, error) {
 	return m.clockOutRecord, m.clockOutErr
+}
+
+func (m *mockClient) ClockInAt(_ time.Time) (int64, error) {
+	return m.clockInID, m.clockInErr
+}
+
+func (m *mockClient) ClockOutAt(_ time.Time) (*AttendanceRecord, error) {
+	return m.clockOutRecord, m.clockOutErr
+}
+
+func (m *mockClient) CreateAttendance(_, _ time.Time) (int64, error) {
+	return m.createAttID, m.createAttErr
+}
+
+func (m *mockClient) EditAttendance(_ int64, _, _ *time.Time) (*AttendanceRecord, error) {
+	return m.editAttRecord, m.editAttErr
 }
 
 func (m *mockClient) AttendanceStatus() (*AttendanceStatus, error) {

--- a/internal/parsing/times.go
+++ b/internal/parsing/times.go
@@ -5,6 +5,36 @@ import (
 	"time"
 )
 
+// ParseClockTime parses a clock time flag value into a concrete time in
+// day's location. Accepted formats: "HH:MM" (resolved on day's date) and
+// "YYYY-MM-DD HH:MM" (explicit date, overrides day).
+func ParseClockTime(s string, day time.Time) (time.Time, error) {
+	loc := day.Location()
+	if t, err := time.ParseInLocation("2006-01-02 15:04", s, loc); err == nil {
+		return t, nil
+	}
+	t, err := time.ParseInLocation("15:04", s, loc)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid time %q: expected HH:MM or YYYY-MM-DD HH:MM", s)
+	}
+	return time.Date(day.Year(), day.Month(), day.Day(),
+		t.Hour(), t.Minute(), 0, 0, loc), nil
+}
+
+// ParseDay parses a YYYY-MM-DD date into midnight in now's location.
+// An empty string means today (now's date).
+func ParseDay(s string, now time.Time) (time.Time, error) {
+	loc := now.Location()
+	if s == "" {
+		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc), nil
+	}
+	t, err := time.ParseInLocation("2006-01-02", s, loc)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid date %q: expected YYYY-MM-DD", s)
+	}
+	return t, nil
+}
+
 // ParseDateRange returns a single-day date range for the given YYYY-MM-DD string.
 func ParseDateRange(date string) (string, string, error) {
 	d, err := time.Parse("2006-01-02", date)

--- a/internal/parsing/times_test.go
+++ b/internal/parsing/times_test.go
@@ -1,6 +1,9 @@
 package parsing
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestWeekDateRange(t *testing.T) {
 	tests := []struct {
@@ -102,6 +105,121 @@ func TestParseDateRange(t *testing.T) {
 			}
 			if to != tt.wantTo {
 				t.Errorf("to = %q, want %q", to, tt.wantTo)
+			}
+		})
+	}
+}
+
+func TestParseClockTime(t *testing.T) {
+	zone := time.FixedZone("CEST", 2*3600)
+	day := time.Date(2026, 7, 16, 0, 0, 0, 0, zone)
+
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:  "bare time HH:MM on the given day",
+			input: "08:30",
+			want:  time.Date(2026, 7, 16, 8, 30, 0, 0, zone),
+		},
+		{
+			name:  "bare time single-digit hour",
+			input: "7:05",
+			want:  time.Date(2026, 7, 16, 7, 5, 0, 0, zone),
+		},
+		{
+			name:  "full datetime overrides the day",
+			input: "2026-07-14 17:15",
+			want:  time.Date(2026, 7, 14, 17, 15, 0, 0, zone),
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "garbage",
+			input:   "later",
+			wantErr: true,
+		},
+		{
+			name:    "out of range time",
+			input:   "25:99",
+			wantErr: true,
+		},
+		{
+			name:    "date without time",
+			input:   "2026-07-14",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseClockTime(tt.input, day)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+			if got.Location() != zone {
+				t.Errorf("location = %v, want %v", got.Location(), zone)
+			}
+		})
+	}
+}
+
+func TestParseDay(t *testing.T) {
+	zone := time.FixedZone("CEST", 2*3600)
+	now := time.Date(2026, 7, 16, 14, 45, 12, 0, zone)
+
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:  "empty input means today at midnight",
+			input: "",
+			want:  time.Date(2026, 7, 16, 0, 0, 0, 0, zone),
+		},
+		{
+			name:  "explicit date",
+			input: "2026-07-14",
+			want:  time.Date(2026, 7, 14, 0, 0, 0, 0, zone),
+		},
+		{
+			name:    "invalid date",
+			input:   "14.07.2026",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDay(tt.input, now)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -101,6 +101,20 @@ func (c *mockClient) ClockOut() (*odoo.AttendanceRecord, error) {
 	c.clockOutCalled = true
 	return nil, c.clockOutErr
 }
+func (c *mockClient) ClockInAt(_ time.Time) (int64, error) {
+	c.clockInCalled = true
+	return 1, c.clockInErr
+}
+func (c *mockClient) ClockOutAt(_ time.Time) (*odoo.AttendanceRecord, error) {
+	c.clockOutCalled = true
+	return nil, c.clockOutErr
+}
+func (c *mockClient) CreateAttendance(_, _ time.Time) (int64, error) {
+	return 1, nil
+}
+func (c *mockClient) EditAttendance(_ int64, _, _ *time.Time) (*odoo.AttendanceRecord, error) {
+	return nil, nil
+}
 func (c *mockClient) AttendanceStatus() (*odoo.AttendanceStatus, error) {
 	return c.attendStatus, c.attendStatusErr
 }


### PR DESCRIPTION
Refs #47 (first step: CLI. The issue stays open — TUI integration and docs are follow-ups.)

Adds backdated clock-in/out and attendance editing to the `clock` command family:

- `clock in --at "08:30"` — clock in at a past time (also `"YYYY-MM-DD HH:MM"`)
- `clock out --at "17:15"` — close the open record at a past time
- `clock edit --in 08:30 [--out 17:15] [--date 2026-07-15] [--id N]` — edit a record's times; if the day has no record and both `--in`/`--out` are given, the record is created (missed-day case); if the day has several records they are listed and `--id` is required

Times are entered in local time and converted to UTC at the odoo layer. Future times are rejected (1-minute clock-skew grace).

## ACL spike findings (dev, throwaway non-admin users)

The issue asks for employee self-service editing, so the first step was determining empirically what a **non-admin** user can do on `hr.attendance` over XML-RPC (dev instance, throwaway users, cleaned up afterwards):

| persona | read own | create | write | unlink |
|---|---|---|---|---|
| plain employee (`base.group_user`) | ✅ | ❌ AccessError | ❌ AccessError | ❌ AccessError |
| officer (`group_hr_attendance_officer`, `attendance_manager_id = self`) | ✅ | ✅ (backdated ok) | ✅ | ✅ |

- `ir.model.access` on Odoo 17: employees get read-only on own records; create/write/unlink need Officer or Administrator.
- The Officer record rule requires `employee_id.attendance_manager_id = user.id` in **both** branches — an officer can only edit records of employees whose attendance manager they are, including their own.
- The sudo'd systray controller (`/hr_attendance/systray_check_in_out`) — the path plain `clock in`/`clock out` uses — accepts **no timestamp** parameter; Odoo 17 has no other sudo'd controller for editing. There is **no employee-level path** for backdated edits; the web UI edit the issue mentions also requires officer rights.

Consequently the feature writes directly over XML-RPC and honestly requires officer rights. When Odoo raises an AccessError the CLI appends a hint:

```
Error: creating attendance record: Fault(4): Sie sind nicht berechtigt „Attendance“-Datensätze (hr.attendance) zu erstellen. …
hint: editing attendance over the API requires the 'Attendance Officer' access right with you set as your own attendance manager; ask your administrator, or use plain 'clock in'/'clock out'
```

Implementation note: go-odoo's transport flattens XML-RPC faults into `net/rpc.ServerError` strings, so `errors.As` on `xmlrpc.FaultError` never matches; AccessError is detected via the locale-independent `"Fault(4):"` message prefix.

## Dev verification transcript (condensed)

All runs against the dev environment; all test records/users deleted afterwards (`clock status` ends at "No attendance records today").

```
$ odoo-work-cli clock in --at "08:05"
Clocked in at 2026-07-16 08:05 (#9)
$ odoo-work-cli clock edit --in 07:50
Updated attendance #9 2026-07-16 07:50 - --:-- (running)
$ odoo-work-cli clock out --at "08:15"
Clocked out at 2026-07-16 08:15
Duration: 0:25 (0.42h)
$ odoo-work-cli clock in --at "08:20" && odoo-work-cli clock out --at "08:22"   # second record
$ odoo-work-cli clock edit --out 08:16
Error: multiple attendance records on that date, select one with --id:
  #10 2026-07-16 08:20 - 08:22 (0:02)
  #9 2026-07-16 07:50 - 08:15 (0:25)
$ odoo-work-cli clock edit --id 9 --out 08:16
Updated attendance #9 2026-07-16 07:50 - 08:16 (0:26)
$ odoo-work-cli clock edit --date 2026-07-15 --in 08:00 --out 12:30             # missed day
Created attendance #11: 2026-07-15 08:00 - 12:30
$ odoo-work-cli clock edit --date 2026-07-14 --in 08:00
Error: no attendance record on 2026-07-14: provide both --in and --out to create one
$ odoo-work-cli clock in --at "23:59"
Error: time 2026-07-16 23:59 is in the future
```

Persona checks through the CLI binary (throwaway users): plain employee gets the hinted AccessError above; a non-admin officer successfully ran `clock in --at`, `clock edit --in`, and `clock out --at`.

## Tests

TDD throughout: table-driven tests for the parsing helpers (`ParseClockTime`, `ParseDay`), an httptest XML-RPC mock asserting the actual create/write payloads (UTC conversion, field sets) and the fault-4 hint path, and tests for the `clock edit` flag-resolution/record-selection helpers. `fetchAttendanceRange` now normalizes range bounds to UTC (with regression test) so callers may pass local times. `mise run test` green, `mise run lint` 0 issues.

## Follow-up

TUI integration (editing attendance from the weekly grid) is not included; it does not fall out naturally from the CLI work since the TUI has no attendance detail view yet.

